### PR TITLE
feat(asr): improve subtitle cue formatting

### DIFF
--- a/app/transcribe.cpp
+++ b/app/transcribe.cpp
@@ -20,6 +20,7 @@
 #include "model_utils.h"
 #include "parameter_parser.h"
 #include "recognizer.h"
+#include "subtitles.h"
 #if defined(NEMO_SPEECH_CLI_NMT)
 #include "speech_translator.h"
 #endif
@@ -28,14 +29,6 @@ namespace {
 namespace fs = std::filesystem;
 namespace asr = nemo_speech::asr;
 
-struct Word {
-    std::string text;
-    int start_ms = 0;
-    int end_ms = 0;
-    float confidence = 0.0f;
-    int speaker = 0;
-};
-
 struct Transcript {
     std::string text;
     std::string source_text;
@@ -43,7 +36,7 @@ struct Transcript {
     float confidence = 0.0f;
     float audio_seconds = 0.0f;
     std::vector<std::string> languages;
-    std::vector<Word> words;
+    std::vector<nemo_speech::subtitle::Word> words;
 };
 
 enum class OutputFormat { Text, Json, Srt, Vtt };
@@ -304,57 +297,6 @@ transcribe_one(asr::Recognizer& recognizer, const Options& options, const fs::pa
     return transcript;
 }
 
-bool
-attaches_to_previous(const std::string& word) {
-    static const std::string punctuation = ".,!?;:%)]}\xE2\x80\x9D\xE2\x80\x99";
-    return !word.empty() && punctuation.find(word) != std::string::npos;
-}
-
-std::string
-join_words(const std::vector<Word>& words, size_t begin, size_t end) {
-    std::string output;
-    for (size_t i = begin; i < end; ++i) {
-        if (!output.empty() && !attaches_to_previous(words[i].text))
-            output += ' ';
-        output += words[i].text;
-    }
-    return output;
-}
-
-struct Cue {
-    int start_ms;
-    int end_ms;
-    std::string text;
-};
-
-std::vector<Cue>
-make_cues(const Transcript& transcript) {
-    std::vector<Cue> cues;
-    if (transcript.words.empty()) {
-        if (!transcript.text.empty())
-            cues.push_back(
-                {0, std::max(1, static_cast<int>(transcript.audio_seconds * 1000)),
-                 transcript.text});
-        return cues;
-    }
-    size_t begin = 0;
-    for (size_t i = 1; i <= transcript.words.size(); ++i) {
-        const bool end = i == transcript.words.size();
-        const int duration =
-            end ? 0 : transcript.words[i].end_ms - transcript.words[begin].start_ms;
-        const int pause = end ? 0 : transcript.words[i].start_ms - transcript.words[i - 1].end_ms;
-        const std::string candidate =
-            end ? std::string() : join_words(transcript.words, begin, i + 1);
-        if (end || duration > 5000 || pause > 800 || candidate.size() > 84) {
-            cues.push_back(
-                {transcript.words[begin].start_ms, transcript.words[i - 1].end_ms,
-                 join_words(transcript.words, begin, i)});
-            begin = i;
-        }
-    }
-    return cues;
-}
-
 std::string
 timestamp(int milliseconds, bool vtt) {
     milliseconds = std::max(0, milliseconds);
@@ -401,7 +343,8 @@ render(const Transcript& t, OutputFormat format, const fs::path& source) {
         const bool vtt = format == OutputFormat::Vtt;
         if (vtt)
             output << "WEBVTT\n\n";
-        const auto cues = make_cues(t);
+        const auto cues = nemo_speech::subtitle::make_cues(
+            t.words, t.text, static_cast<int>(t.audio_seconds * 1000));
         for (size_t i = 0; i < cues.size(); ++i) {
             if (!vtt)
                 output << i + 1 << '\n';

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,8 @@ curl -X POST http://127.0.0.1:8080/v1/audio/transcriptions \
 
 Response (`json`): `{"text": "..."}`. `verbose_json` adds `task`, `language`,
 `duration`, and `words[]` (`word`, `start`, `end`, `confidence`, and `speaker`
-when diarization is on).
+when diarization is on). SRT and WebVTT responses use the same readable,
+punctuation-aware cue grouping as the file CLI.
 
 ## WebSocket /v1/realtime
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,10 @@ nemo-speech transcribe recording.wav --format vtt --output recording.vtt
 nemo-speech transcribe recording.wav --json --word-times
 ```
 
+SRT and WebVTT cues prefer sentence, clause, and pause boundaries. Cues use up
+to two lines, target 37 characters per line, and allow small whole-word
+overflow within the common 42-character subtitle limit.
+
 Plain results are written to stdout. Progress and diagnostics are written to
 stderr so output can be redirected safely. Global `--json`, `--quiet`, and
 `--verbose` options work across commands.

--- a/server/http/http_server.cpp
+++ b/server/http/http_server.cpp
@@ -22,6 +22,7 @@
 #include "audio_resampler.h"
 #include "engine_registry.h"
 #include "json.h"
+#include "subtitles.h"
 
 namespace nemo_speech::http {
 namespace {
@@ -273,12 +274,21 @@ transcript_response(
         return alternative.transcript + "\n";
     if (format == "srt" || format == "vtt") {
         const bool vtt = format == "vtt";
-        int end = std::max(1, static_cast<int>(std::round(result.audio_processed * 1000)));
-        if (!alternative.words.empty())
-            end = std::max(end, alternative.words.back().end_time);
-        std::string output = vtt ? "WEBVTT\n\n" : "1\n";
-        output += timecode(0, vtt) + " --> " + timecode(end, vtt) + "\n";
-        output += alternative.transcript + "\n";
+        int audio_ms = std::max(1, static_cast<int>(std::round(result.audio_processed * 1000)));
+        std::vector<subtitle::Word> words;
+        words.reserve(alternative.words.size());
+        for (const auto& word : alternative.words)
+            words.push_back(
+                {word.word, word.start_time, word.end_time, word.confidence, word.speaker_tag});
+        const auto cues = subtitle::make_cues(words, alternative.transcript, audio_ms);
+        std::string output = vtt ? "WEBVTT\n\n" : "";
+        for (size_t i = 0; i < cues.size(); ++i) {
+            if (!vtt)
+                output += std::to_string(i + 1) + "\n";
+            output += timecode(cues[i].start_ms, vtt) + " --> " +
+                      timecode(std::max(cues[i].start_ms + 1, cues[i].end_ms), vtt) + "\n";
+            output += cues[i].text + "\n\n";
+        }
         return output;
     }
     Value root(Value::Object{});
@@ -553,7 +563,8 @@ struct Server::Impl {
                     form_bool(request, "automatic_punctuation", true);
                 options.verbatim_transcripts = form_bool(request, "verbatim");
                 options.profanity_filter = form_bool(request, "profanity_filter");
-                options.enable_word_time_offsets = format == "verbose_json";
+                options.enable_word_time_offsets =
+                    format == "verbose_json" || format == "srt" || format == "vtt";
                 options.enable_speaker_diarization = form_bool(request, "diarization");
                 if (options.enable_speaker_diarization) {
                     const std::string speakers = form_value(request, "max_speaker_count");

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(nemo_speech_common STATIC
     audio_resampler.cpp
     json.cpp
     parameter_parser.cpp
+    subtitles.cpp
 )
 
 # Public so config headers' `#include "parameter_parser.h"` reaches every

--- a/src/common/subtitles.cpp
+++ b/src/common/subtitles.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "subtitles.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <sstream>
+
+namespace nemo_speech::subtitle {
+namespace {
+
+// BBC broadcast subtitles target two 37-character lines and 180 words per
+// minute. Netflix permits a 42-character outer line bound and cue durations
+// from 5/6 second through 7 seconds.
+constexpr int kTargetLineCharacters = 37;
+constexpr int kMaximumCueCharacters = 2 * kTargetLineCharacters;
+constexpr int kMaximumCueDurationMs = 7000;
+constexpr int kMinimumCueDurationMs = 834;
+constexpr int kPauseBoundaryMs = 800;
+constexpr int kWordsPerMinute = 180;
+
+bool
+starts_with_any(const std::string& value, const std::vector<std::string>& prefixes) {
+    for (const auto& prefix : prefixes)
+        if (value.rfind(prefix, 0) == 0)
+            return true;
+    return false;
+}
+
+bool
+ends_with_any(const std::string& value, const std::vector<std::string>& suffixes) {
+    for (const auto& suffix : suffixes)
+        if (value.size() >= suffix.size() &&
+            value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0)
+            return true;
+    return false;
+}
+
+bool
+attaches_to_previous(const std::string& word) {
+    static const std::vector<std::string> punctuation{
+        ".",  ",",  "!",  "?",  ";",  ":",  "%",  ")",  "]", "}", "\xE2\x80\x9D", "\xE2\x80\x99",
+        "。", "，", "！", "？", "；", "：", "）", "】", "》"};
+    return starts_with_any(word, punctuation);
+}
+
+bool
+sentence_end(const std::string& word) {
+    static const std::vector<std::string> punctuation{".",  "!",  "?", "\xE2\x80\xA6",
+                                                      "。", "！", "？"};
+    return ends_with_any(word, punctuation);
+}
+
+bool
+clause_end(const std::string& word) {
+    static const std::vector<std::string> punctuation{
+        ",", ";", ":", "\xE2\x80\x94", "\xE2\x80\x93", "，", "；", "："};
+    return ends_with_any(word, punctuation);
+}
+
+size_t
+character_count(const std::string& text) {
+    size_t count = 0;
+    for (const unsigned char byte : text)
+        if ((byte & 0xc0) != 0x80)
+            ++count;
+    return count;
+}
+
+std::string
+join_words(const std::vector<Word>& words, size_t begin, size_t end) {
+    std::ostringstream output;
+    for (size_t i = begin; i < end; ++i) {
+        if (output.tellp() > 0 && !attaches_to_previous(words[i].text))
+            output << ' ';
+        output << words[i].text;
+    }
+    return output.str();
+}
+
+std::string
+format_lines(const std::vector<Word>& words, size_t begin, size_t end) {
+    std::string text = join_words(words, begin, end);
+    if (end - begin <= 1 || character_count(text) <= kTargetLineCharacters)
+        return text;
+
+    size_t best_break = begin + 1;
+    bool best_punctuation = false;
+    size_t best_overflow = std::numeric_limits<size_t>::max();
+    size_t best_imbalance = std::numeric_limits<size_t>::max();
+    for (size_t split = begin + 1; split < end; ++split) {
+        const std::string left = join_words(words, begin, split);
+        const std::string right = join_words(words, split, end);
+        const size_t left_length = character_count(left);
+        const size_t right_length = character_count(right);
+        const size_t overflow =
+            (left_length > kTargetLineCharacters ? left_length - kTargetLineCharacters : 0) +
+            (right_length > kTargetLineCharacters ? right_length - kTargetLineCharacters : 0);
+        const bool punctuation =
+            sentence_end(words[split - 1].text) || clause_end(words[split - 1].text);
+        const size_t imbalance =
+            left_length > right_length ? left_length - right_length : right_length - left_length;
+        if (overflow < best_overflow ||
+            (overflow == best_overflow && punctuation && !best_punctuation) ||
+            (overflow == best_overflow && punctuation == best_punctuation &&
+             imbalance < best_imbalance)) {
+            best_break = split;
+            best_punctuation = punctuation;
+            best_overflow = overflow;
+            best_imbalance = imbalance;
+        }
+    }
+    return join_words(words, begin, best_break) + '\n' + join_words(words, best_break, end);
+}
+
+struct Group {
+    size_t begin;
+    size_t end;
+    Cue cue;
+};
+
+}  // namespace
+
+std::vector<Cue>
+make_cues(const std::vector<Word>& words, const std::string& fallback_text, int audio_ms) {
+    if (words.empty()) {
+        if (fallback_text.empty())
+            return {};
+        return {{0, std::max(1, audio_ms), fallback_text}};
+    }
+
+    std::vector<Group> groups;
+    for (size_t begin = 0; begin < words.size();) {
+        size_t end = begin + 1;
+        size_t last_clause = begin;
+        bool has_clause = false;
+        for (; end <= words.size(); ++end) {
+            const size_t current = end - 1;
+            if (end > begin + 1) {
+                const bool pause =
+                    words[current].start_ms - words[current - 1].end_ms > kPauseBoundaryMs;
+                const bool too_long =
+                    words[current].end_ms - words[begin].start_ms > kMaximumCueDurationMs;
+                const bool too_many_characters =
+                    character_count(join_words(words, begin, end)) > kMaximumCueCharacters;
+                if (pause || too_long || too_many_characters) {
+                    --end;
+                    if (!pause && has_clause)
+                        end = last_clause;
+                    break;
+                }
+            }
+            if (clause_end(words[current].text)) {
+                last_clause = end;
+                has_clause = true;
+            }
+            if (sentence_end(words[current].text))
+                break;
+        }
+        end = std::min(std::max(end, begin + 1), words.size());
+        groups.push_back(
+            {begin,
+             end,
+             {std::max(0, words[begin].start_ms),
+              std::min(words[end - 1].end_ms, words[begin].start_ms + kMaximumCueDurationMs),
+              format_lines(words, begin, end)}});
+        begin = end;
+    }
+
+    std::vector<Cue> cues;
+    cues.reserve(groups.size());
+    for (size_t i = 0; i < groups.size(); ++i) {
+        auto cue = groups[i].cue;
+        const int available_end =
+            i + 1 < groups.size() ? groups[i + 1].cue.start_ms : std::max(cue.end_ms, audio_ms);
+        const int words_in_cue = static_cast<int>(groups[i].end - groups[i].begin);
+        const int readable_ms = std::max(
+            kMinimumCueDurationMs, (words_in_cue * 60000 + kWordsPerMinute - 1) / kWordsPerMinute);
+        const int desired_end = cue.start_ms + std::min(readable_ms, kMaximumCueDurationMs);
+        cue.end_ms = std::min(
+            std::max(cue.end_ms, desired_end),
+            std::min(available_end, cue.start_ms + kMaximumCueDurationMs));
+        if (cue.end_ms <= cue.start_ms)
+            cue.end_ms = cue.start_ms + 1;
+        cues.push_back(std::move(cue));
+    }
+    return cues;
+}
+
+}  // namespace nemo_speech::subtitle

--- a/src/common/subtitles.cpp
+++ b/src/common/subtitles.cpp
@@ -4,6 +4,7 @@
 #include "subtitles.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstddef>
 #include <limits>
 #include <sstream>
@@ -14,6 +15,10 @@ namespace {
 // BBC broadcast subtitles target two 37-character lines and 180 words per
 // minute. Netflix permits a 42-character outer line bound and cue durations
 // from 5/6 second through 7 seconds.
+// References:
+// https://www.bbc.co.uk/accessibility/forproducts/guides/subtitles/
+// https://partnerhelp.netflixstudios.com/hc/en-us/articles/215758617-Timed-Text-Style-Guide-General-Requirements
+// https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines
 constexpr int kTargetLineCharacters = 37;
 constexpr int kMaximumCueCharacters = 2 * kTargetLineCharacters;
 constexpr int kMaximumCueDurationMs = 7000;
@@ -47,10 +52,22 @@ attaches_to_previous(const std::string& word) {
 }
 
 bool
+is_title_abbreviation(const std::string& word) {
+    std::string lower;
+    lower.reserve(word.size());
+    for (const unsigned char character : word)
+        lower.push_back(static_cast<char>(std::tolower(character)));
+    static const std::vector<std::string> titles{"capt.", "cmdr.", "col.", "dr.",  "gen.",
+                                                 "gov.",  "lt.",   "mr.",  "mrs.", "ms.",
+                                                 "prof.", "rep.",  "rev.", "sen.", "sgt."};
+    return std::find(titles.begin(), titles.end(), lower) != titles.end();
+}
+
+bool
 sentence_end(const std::string& word) {
     static const std::vector<std::string> punctuation{".",  "!",  "?", "\xE2\x80\xA6",
                                                       "。", "！", "？"};
-    return ends_with_any(word, punctuation);
+    return !is_title_abbreviation(word) && ends_with_any(word, punctuation);
 }
 
 bool
@@ -115,6 +132,14 @@ format_lines(const std::vector<Word>& words, size_t begin, size_t end) {
     return join_words(words, begin, best_break) + '\n' + join_words(words, best_break, end);
 }
 
+bool
+has_minimum_display_time(const std::vector<Word>& words, size_t begin, size_t end, int audio_ms) {
+    const int cue_start = std::max(0, words[begin].start_ms);
+    const int available_end =
+        end < words.size() ? words[end].start_ms : std::max(words[end - 1].end_ms, audio_ms);
+    return available_end - cue_start >= kMinimumCueDurationMs;
+}
+
 struct Group {
     size_t begin;
     size_t end;
@@ -156,7 +181,8 @@ make_cues(const std::vector<Word>& words, const std::string& fallback_text, int 
                 last_clause = end;
                 has_clause = true;
             }
-            if (sentence_end(words[current].text))
+            if (sentence_end(words[current].text) &&
+                has_minimum_display_time(words, begin, end, audio_ms))
                 break;
         }
         end = std::min(std::max(end, begin + 1), words.size());

--- a/src/common/subtitles.h
+++ b/src/common/subtitles.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace nemo_speech::subtitle {
+
+struct Word {
+    std::string text;
+    int start_ms = 0;
+    int end_ms = 0;
+    float confidence = 0.0f;
+    int speaker = 0;
+};
+
+struct Cue {
+    int start_ms = 0;
+    int end_ms = 0;
+    std::string text;
+};
+
+std::vector<Cue> make_cues(
+    const std::vector<Word>& words, const std::string& fallback_text, int audio_ms);
+
+}  // namespace nemo_speech::subtitle

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -15,6 +15,11 @@ target_link_libraries(test_shared_utilities PRIVATE
     nemo_speech_common nemo_speech_engine_registry)
 add_test(NAME shared_utilities COMMAND test_shared_utilities)
 
+add_executable(test_subtitles
+    ${CMAKE_SOURCE_DIR}/tests/cpp/common/test_subtitles.cpp)
+target_link_libraries(test_subtitles PRIVATE nemo_speech_common)
+add_test(NAME subtitles COMMAND test_subtitles)
+
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND AND
    (NEMO_SPEECH_BUILD_ASR OR NEMO_SPEECH_BUILD_DIAR OR

--- a/tests/cpp/common/test_subtitles.cpp
+++ b/tests/cpp/common/test_subtitles.cpp
@@ -67,6 +67,41 @@ test_sentence_and_pause_boundaries() {
 }
 
 void
+test_adjacent_short_sentences_share_a_cue() {
+    const std::vector<Word> words{{"Yes.", 0, 250}, {"No.", 250, 1000}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 1000);
+    require(cues.size() == 1, "adjacent short sentences share one cue");
+    require(cues[0].text == "Yes. No.", "short sentence text is preserved");
+    require(cues[0].end_ms - cues[0].start_ms >= 834, "combined cue meets minimum duration");
+}
+
+void
+test_short_sentence_with_time_stays_separate() {
+    const std::vector<Word> words{{"Yes.", 0, 250}, {"No.", 900, 1200}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 1800);
+    require(cues.size() == 2, "short sentence stays separate when display time is available");
+    require(cues[0].text == "Yes." && cues[0].end_ms == 834, "first cue uses minimum duration");
+    require(cues[1].start_ms == 900 && cues[1].end_ms == 1734, "second cue uses minimum duration");
+}
+
+void
+test_title_abbreviation_does_not_split_sentence() {
+    const std::vector<Word> words{{"Dr.", 0, 220}, {"Smith", 220, 600}, {"arrived.", 600, 1054}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 1054);
+    require(cues.size() == 1, "title abbreviation stays with its sentence");
+    require(cues[0].text == "Dr. Smith arrived.", "abbreviation sentence text");
+}
+
+void
+test_suffix_abbreviation_can_end_sentence() {
+    const std::vector<Word> words{
+        {"John", 0, 220}, {"Jr.", 220, 450}, {"He", 900, 1050}, {"left.", 1050, 1400}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 1800);
+    require(cues.size() == 2, "suffix abbreviation may end a sentence");
+    require(cues[0].text == "John Jr." && cues[1].text == "He left.", "suffix sentence text");
+}
+
+void
 test_two_lines_and_utf8_character_count() {
     const std::vector<Word> words{
         {"Друзья,", 0, 300},      {"сегодня", 300, 600},       {"мы", 600, 800},
@@ -112,6 +147,10 @@ int
 main() {
     test_clause_wrapping_and_readable_duration();
     test_sentence_and_pause_boundaries();
+    test_adjacent_short_sentences_share_a_cue();
+    test_short_sentence_with_time_stays_separate();
+    test_title_abbreviation_does_not_split_sentence();
+    test_suffix_abbreviation_can_end_sentence();
     test_two_lines_and_utf8_character_count();
     test_duration_and_length_split_are_ordered();
     test_fallback_text();

--- a/tests/cpp/common/test_subtitles.cpp
+++ b/tests/cpp/common/test_subtitles.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "subtitles.h"
+
+using nemo_speech::subtitle::Cue;
+using nemo_speech::subtitle::Word;
+
+namespace {
+
+void
+require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+size_t
+characters(const std::string& text) {
+    size_t count = 0;
+    for (const unsigned char byte : text)
+        if ((byte & 0xc0) != 0x80)
+            ++count;
+    return count;
+}
+
+std::vector<std::string>
+lines(const std::string& text) {
+    const auto split = text.find('\n');
+    if (split == std::string::npos)
+        return {text};
+    return {text.substr(0, split), text.substr(split + 1)};
+}
+
+void
+test_clause_wrapping_and_readable_duration() {
+    const std::vector<Word> words{{"When", 0, 300},        {"we", 300, 500},
+                                  {"arrived,", 500, 900},  {"the", 900, 1100},
+                                  {"station", 1100, 1500}, {"was", 1500, 1700},
+                                  {"already", 1700, 2100}, {"closed.", 2100, 2500}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 4000);
+    require(cues.size() == 1, "one grammatical cue");
+    require(
+        cues[0].text == "When we arrived,\nthe station was already closed.",
+        "prefer clause punctuation when wrapping");
+    require(cues[0].start_ms == 0 && cues[0].end_ms == 2667, "180 WPM display time");
+}
+
+void
+test_sentence_and_pause_boundaries() {
+    const std::vector<Word> words{
+        {"First", 0, 300},
+        {"sentence.", 300, 600},
+        {"After", 1600, 1900},
+        {"a", 1900, 2000},
+        {"pause", 2000, 2300}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 3000);
+    require(cues.size() == 2, "sentence and pause produce two cues");
+    require(cues[0].text == "First sentence.", "first sentence text");
+    require(cues[0].end_ms <= cues[1].start_ms, "cues do not overlap");
+}
+
+void
+test_two_lines_and_utf8_character_count() {
+    const std::vector<Word> words{
+        {"Друзья,", 0, 300},      {"сегодня", 300, 600},       {"мы", 600, 800},
+        {"обсуждаем", 800, 1200}, {"современное", 1200, 1600}, {"образование", 1600, 2000},
+        {"и", 2000, 2100},        {"его", 2100, 2300},         {"будущее.", 2300, 2700}};
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 3500);
+    require(cues.size() == 1, "UTF-8 words stay in one cue");
+    const auto wrapped = lines(cues[0].text);
+    require(wrapped.size() == 2, "at most two subtitle lines");
+    require(
+        characters(wrapped[0]) <= 42 && characters(wrapped[1]) <= 42, "42-character outer bound");
+}
+
+void
+test_duration_and_length_split_are_ordered() {
+    std::vector<Word> words;
+    words.reserve(30);
+    for (int i = 0; i < 30; ++i)
+        words.push_back({"word" + std::to_string(i), i * 400, i * 400 + 300});
+    const auto cues = nemo_speech::subtitle::make_cues(words, "", 12500);
+    require(cues.size() >= 2, "long transcript splits into cues");
+    int previous_end = 0;
+    for (const Cue& cue : cues) {
+        require(cue.start_ms >= previous_end, "ordered non-overlapping cues");
+        require(cue.end_ms > cue.start_ms, "positive cue duration");
+        require(cue.end_ms - cue.start_ms <= 7000, "seven-second cue maximum");
+        require(lines(cue.text).size() <= 2, "two-line cue maximum");
+        previous_end = cue.end_ms;
+    }
+}
+
+void
+test_fallback_text() {
+    const auto cues = nemo_speech::subtitle::make_cues({}, "Fallback transcript.", 1200);
+    require(cues.size() == 1, "fallback cue");
+    require(cues[0].start_ms == 0 && cues[0].end_ms == 1200, "fallback timing");
+    require(cues[0].text == "Fallback transcript.", "fallback text");
+}
+
+}  // namespace
+
+int
+main() {
+    test_clause_wrapping_and_readable_duration();
+    test_sentence_and_pause_boundaries();
+    test_two_lines_and_utf8_character_count();
+    test_duration_and_length_split_are_ordered();
+    test_fallback_text();
+    std::cout << "subtitle tests passed\n";
+    return 0;
+}

--- a/tests/integration/http_conformance_test.py
+++ b/tests/integration/http_conformance_test.py
@@ -271,6 +271,17 @@ def main() -> None:
                     is not None,
                     "WebVTT timestamps",
                 )
+            blocks = subtitle.text.strip().split("\n\n")
+            if response_format == "vtt":
+                blocks = blocks[1:]
+            text_lines = []
+            for block in blocks:
+                lines = block.splitlines()
+                cue_text = lines[2:] if response_format == "srt" else lines[1:]
+                require(1 <= len(cue_text) <= 2, "subtitle cue line count")
+                text_lines.extend(cue_text)
+            require(text_lines, "subtitle cue text")
+            require(max(map(len, text_lines)) <= 42, "subtitle line length")
 
         with wave.open(args.audio, "rb") as audio:
             require(audio.getnchannels() == 1, "WebSocket fixture must be mono")


### PR DESCRIPTION
## summary

Make SRT and WebVTT subtitles easier to read by using one formatter for both the command line and HTTP API.

Previously, command-line subtitles could produce long single-line cues, reaching 83 characters in the one-minute test. HTTP responses could also place a whole recording in one subtitle.

The formatter:

- splits subtitles at sentences, clauses, and pauses
- uses up to two lines, targeting 37 characters and generally staying within 42 without breaking words
- sets display time based on a reading speed of about 180 words per minute
- displays each subtitle for 5/6 of a second to 7 seconds where timing permits
- keeps the recognized text unchanged

These readability targets are informed by the
[BBC subtitle guidelines](https://www.bbc.co.uk/accessibility/forproducts/guides/subtitles/)
and Netflix's
[general timed-text requirements](https://partnerhelp.netflixstudios.com/hc/en-us/articles/215758617-Timed-Text-Style-Guide-General-Requirements)
and
[timing guidelines](https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines).
They are not a claim of full BBC or Netflix compliance.

## provenance

The subtitle splitting and line wrapping were adapted from my MIT-licensed
[chough formatter](https://github.com/hyperpuncher/chough/blob/dfe599eebaf73bfc035a755ecaa8282b45bf44cb/internal/output/vtt.go).

I own the copyright to that implementation and submit this C++ adaptation under this repository's Apache 2.0 license.
