### PR TITLE
fix(asr): preserve TDT skips across decoder steps

### DIFF
--- a/src/asr/decoders/rnnt_greedy_decoder.cpp
+++ b/src/asr/decoders/rnnt_greedy_decoder.cpp
@@ -355,6 +355,7 @@ TdtGreedyDecoder::reset() {
     prev_token_ = engine_->rnnt_config().blank_id;
     active_bank_ = 0;
     predictor_valid_ = false;
+    pending_skip_ = 0;
     stats_ = {};
     last_emit_frame_ = -1;
     words_.clear();
@@ -364,6 +365,7 @@ TdtGreedyDecoder::reset() {
 
 void
 TdtGreedyDecoder::reset_utterance() {
+    pending_skip_ = 0;
     words_.clear();
     cur_open_ = false;
     cur_ = WordTiming{};
@@ -394,7 +396,8 @@ TdtGreedyDecoder::step(const float* enc_out, int d_model, int T, int64_t frame_o
     DecodeStepScope decode_scope(engine_);
 
     stats_.encoder_frames += static_cast<uint64_t>(T);
-    int t = 0;
+    int t = pending_skip_;
+    pending_skip_ = 0;
     while (t < T) {
         int symbols_added = 0;
         bool need_loop = true;
@@ -461,6 +464,7 @@ TdtGreedyDecoder::step(const float* enc_out, int d_model, int T, int64_t frame_o
         if (symbols_added == cfg.max_symbols_per_step && skip == 0)
             ++t;
     }
+    pending_skip_ = std::max(0, t - T);
     return emitted;
 }
 

--- a/src/asr/decoders/rnnt_greedy_decoder.h
+++ b/src/asr/decoders/rnnt_greedy_decoder.h
@@ -254,6 +254,10 @@ class TdtGreedyDecoder : public Decoder {
     int prev_token_ = -1;
     int active_bank_ = 0;
     bool predictor_valid_ = false;
+    // A duration may advance past the end of one encoder block. Carry that
+    // remainder into the next step() so segmented and contiguous decoding
+    // present the same encoder clock to TDT.
+    int pending_skip_ = 0;
     RnntDecodeStats stats_;
     int64_t last_emit_frame_ = -1;
     bool compute_ts_ = false;

--- a/tests/cpp/asr/test_decoders.cpp
+++ b/tests/cpp/asr/test_decoders.cpp
@@ -579,6 +579,25 @@ test_tdt_zero_duration_guard() {
     check(ids.empty() && eng.joint_calls == 1, "tdt: blank duration zero advances immediately");
 }
 
+void
+test_tdt_duration_crosses_step_boundary() {
+    MockTdtEngine eng;
+    TdtGreedyDecoder dec(&eng);
+    const int blank = eng.rnnt_config().blank_id;
+    std::vector<float> frame(2, 0.0f);
+    eng.rounds = {{blank, 2}};
+    check(dec.step(frame.data(), 2, 1, 0).empty(), "tdt: boundary setup is blank");
+
+    const int calls_before_skip = eng.joint_calls;
+    check(dec.step(frame.data(), 2, 1, 1).empty(), "tdt: carried duration skips a whole block");
+    check(eng.joint_calls == calls_before_skip, "tdt: skipped block performs no joint call");
+
+    eng.rounds = {{0, 1}};
+    const auto ids = dec.step(frame.data(), 2, 1, 2);
+    check(ids == std::vector<int>({0}), "tdt: emits after carried duration");
+    check(dec.last_emit_frame() == 2, "tdt: carries duration across step boundaries");
+}
+
 }  // namespace
 
 int
@@ -602,6 +621,7 @@ main() {
     test_rnnt_open_word_needs_finalize();
     test_tdt_duration_and_state_commit();
     test_tdt_zero_duration_guard();
+    test_tdt_duration_crosses_step_boundary();
     std::fprintf(stdout, g_fail ? "FAILED (%d)\n" : "ALL PASS\n", g_fail);
     return g_fail ? 1 : 0;
 }


### PR DESCRIPTION
## summary

Keep TDT frame skips when they cross into the next audio block.

TDT tells the decoder how many frames to move forward. Previously, the decoder forgot any remaining move when it reached the end of a block.

In this example, the current block ends at frame 100. Moving forward by 3 should continue at frame 103.

| | Frame 100 | Frame 101 | Frame 102 | Frame 103 |
|---|---|---|---|---|
| Before | Move forward 3 | Continue too early ❌ | | |
| After | Move forward 3 | Skip | Skip | Continue ✅ |

The decoder now remembers the remaining move across blocks and clears it when starting a new recording.
