### PR TITLE
fix(metal): stop MagpieTTS returning silence on M5-class devices

### DIFF
--- a/ggml-patches/0018-metal-tensor-api-dynamic-k.patch
+++ b/ggml-patches/0018-metal-tensor-api-dynamic-k.patch
@@ -1,0 +1,60 @@
+diff --git a/src/ggml-metal/ggml-metal.metal b/src/ggml-metal/ggml-metal.metal
+index f6ffb2b..55ad5ea 100644
+--- a/src/ggml-metal/ggml-metal.metal
++++ b/src/ggml-metal/ggml-metal.metal
+@@ -9412,9 +9412,12 @@ kernel void kernel_mul_mm(
+     auto tB = tensor(ptrB, dextents<int32_t, 2>(K, N), array<int, 2>({1, strideB}));
+ 
+     // Configure matmul operation
++    // note: K is dynamic_extent (clamped to the valid range in PHASE 2), since a static
++    //       N_MM_NK_TOTAL K tile would read src1 out of bounds when K % N_MM_NK_TOTAL != 0
++    // ref: https://github.com/ggml-org/llama.cpp/pull/27064
+     mpp::tensor_ops::matmul2d<
+         mpp::tensor_ops::matmul2d_descriptor(
+-            NRB, NRA, N_MM_NK_TOTAL, false, true, true,
++            NRB, NRA, static_cast<int>(dynamic_extent), false, true, true,
+             mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+         execution_simdgroups<N_MM_SIMD_GROUP_X * N_MM_SIMD_GROUP_Y>> mm;
+ 
+@@ -9466,10 +9469,14 @@ kernel void kernel_mul_mm(
+         threadgroup_barrier(mem_flags::mem_threadgroup);
+ 
+         // === PHASE 2: Tensor matmul ===
+-        auto mA = tA.slice(0, 0);
+-        auto mB = tB.slice(loop_k, rb);
++        // Clamp the K extent of both operand tensors to the remaining valid K range so
++        // the dynamic-K op never reads past the K extent of src1 (or the staged A tile).
++        const int kExt = min(N_MM_NK_TOTAL, K - loop_k);
+ 
+-        mm.run(mB, mA, cT);
++        auto tAv = tensor(sa, dextents<int32_t, 2>(kExt, NRA), array<int, 2>({1, N_MM_NK_TOTAL}));
++        auto tBv = tensor(ptrB + loop_k + rb * strideB, dextents<int32_t, 2>(kExt, N - rb), array<int, 2>({1, strideB}));
++
++        mm.run(tBv, tAv, cT);
+ 
+         threadgroup_barrier(mem_flags::mem_threadgroup);
+     }
+diff --git a/tests/test-backend-ops.cpp b/tests/test-backend-ops.cpp
+index f54ab41..85e0e92 100644
+--- a/tests/test-backend-ops.cpp
++++ b/tests/test-backend-ops.cpp
+@@ -8401,6 +8401,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
+     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F32, GGML_TYPE_F32, 16, 32, 32, { 1,  1}, {1, 1}, {0, 1, 2, 3}, 64, 3));
+     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F32, GGML_TYPE_F32, 64, 77, 77, {12,1}, {1,1}));
+ 
++    // K not a multiple of 32 - exercises the partial-K tile of the Metal tensor API
++    // mat-mat kernel, which previously read past the K extent of src1 (ggml 33c9ea5)
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 64, 32,   65, {1, 1}, {1, 1}));
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 64, 32,   80, {1, 1}, {1, 1}));
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F32, 64, 32,   80, {1, 1}, {1, 1}));
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F32, GGML_TYPE_F32, 64, 32,   80, {1, 1}, {1, 1}));
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 64, 32,  588, {1, 1}, {1, 1})); // 14*14*3, e.g. conv_2d im2col
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 64, 32,   80, {4, 1}, {1, 1}));
++    // NanoCodec residual input convolution: K = 1296 (1296 % 32 == 16), plus an aligned control
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16,  8, 432, 1296, {1, 1}, {1, 1}));
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 32, 432, 1296, {1, 1}, {1, 1}));
++    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 32, 432, 1280, {1, 1}, {1, 1}));
++
+     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 576, 512, 576, {1,1}, {1,1}));
+     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 1, 2048, 8192, {1,  1}, {1, 1}));
+     for (ggml_type type_a : all_types) {

--- a/ggml-patches/README.md
+++ b/ggml-patches/README.md
@@ -9,13 +9,20 @@ git submodule update --init ggml
 scripts/apply-ggml-patches.sh        # applies patches in filename order
 ```
 
-Patched CUDA builds expect the patches before CMake configuration; CPU, Metal,
-Vulkan, and stock-CUDA builds do not. `apply-ggml-patches.sh` uses `git apply`,
-skips patches that are already applied, and applies new patches in filename
-order. Later patches may build on files changed by earlier patches; 0006 carries
-the dispatch wiring for the ops/kernels introduced by 0001/0003/0005. Docker
-builds and `scripts/configure.sh` apply the series automatically; apply it
-explicitly before a raw CUDA CMake configuration.
+Patched CUDA and Metal builds expect the patches before CMake configuration.
+CPU, Vulkan, and stock-CUDA builds do not. `apply-ggml-patches.sh` uses `git
+apply`, skips patches that are already applied, and applies new patches in
+filename order. Later patches may build on files changed by earlier patches;
+0006 carries the dispatch wiring for the ops/kernels introduced by
+0001/0003/0005. Docker builds and `scripts/configure.sh` apply the series
+automatically; apply it explicitly before a raw CUDA or Metal CMake
+configuration.
+
+Metal requires only 0018, the one patch that touches the Metal backend. The
+`metal-*` presets apply the whole series because `apply-ggml-patches.sh`
+requires all of them or it fails. Once the submodule moves past upstream ggml
+`33c9ea5`, drop 0018 as described below and remove `metal-*` from the `case` in
+`scripts/configure.sh`.
 
 ## Building against patched vs stock ggml
 
@@ -116,6 +123,11 @@ stock comparison therefore requires both a pristine ggml checkout and
 
 - **0017-cuda-stream-interop.patch** - exposes borrowed access to the active
   CUDA stream and stable graph templates for external graph composition.
+
+- **0018-metal-tensor-api-dynamic-k.patch** - backports upstream ggml `33c9ea5`
+  (llama/27450), which stops the Metal tensor-API matmul reading `src1` out of
+  bounds when `K % 32 != 0`. Drop it once the submodule passes that commit,
+  keeping the `K = 1296` test case.
 
 ## Regenerating after editing ggml
 

--- a/scripts/apply-ggml-patches.sh
+++ b/scripts/apply-ggml-patches.sh
@@ -51,8 +51,11 @@ if git -C "${GGML}" rev-parse --git-dir >/dev/null 2>&1; then
         fi
     done
 
-    mapfile -d '' patched_paths \
-        < <(GIT_INDEX_FILE="${expected_index}" git -C "${GGML}" \
+    # note: not mapfile -d '' - that is bash 4+, and macOS ships bash 3.2
+    patched_paths=()
+    while IFS= read -r -d '' path; do
+        patched_paths+=("${path}")
+    done < <(GIT_INDEX_FILE="${expected_index}" git -C "${GGML}" \
             diff --cached --name-only -z HEAD)
     GIT_INDEX_FILE="${current_index}" git -C "${GGML}" read-tree HEAD
     current_paths=()

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -22,7 +22,7 @@ Examples:
   scripts/configure.sh cuda-server -DNEMO_SPEECH_WITH_NORM=ON
 
 The script checks required submodules and optional feature assets, applies the
-pinned ggml patch series for CUDA presets, and then runs cmake --preset PRESET.
+pinned ggml patch series for CUDA and Metal presets, and then runs cmake --preset PRESET.
 EOF
     exit 0
 fi
@@ -65,7 +65,8 @@ cmake_bool_override() { # cmake_bool_override VARIABLE DEFAULT ARGS...
         key="${key%%:*}"
         [ "$key" = "$variable" ] || continue
         setting="${definition#*=}"
-        setting="${setting^^}"
+        # note: not ${setting^^} - that is bash 4+, and macOS ships bash 3.2
+        setting="$(printf '%s' "${setting}" | tr '[:lower:]' '[:upper:]')"
         case "$setting" in
             ON|TRUE|YES|1) value=ON ;;
             OFF|FALSE|NO|0) value=OFF ;;
@@ -160,7 +161,7 @@ if [ "${#missing[@]}" -ne 0 ]; then
 fi
 
 case "$PRESET" in
-    cuda-*)
+    cuda-*|metal-*)
         scripts/apply-ggml-patches.sh
         ;;
 esac


### PR DESCRIPTION
Fixes the silent text-to-speech reported in #19.

## What happens

On M5-class Apple chips every synthesis writes a valid WAV whose samples are all `-32767`. The command exits 0 with a plausible duration and a normal realtime factor, so nothing in the logs gives it away. `--device auto` picks Metal on Apple Silicon, so a stock install does not speak.

## Cause

ggml drives the M5's per-core matrix hardware (Neural Accelerators) through the Metal 4 tensor API, compiled in as `GGML_METAL_HAS_TENSOR`. That path multiplies in fixed 32-wide chunks of the shared dimension K, and on the final partial chunk it still handed `matmul2d` a full 32-wide tile, reading `src1` past its end. MSL 2.22.2 leaves that undefined; in practice it returns NaN.

NanoCodec's residual input convolutions are `ggml_mul_mat` with `K = 1296`, and `1296 % 32 == 16`, so the decoder emits NaN. Two safety nets then hide it: `ggml_clamp(x, -1, 1)` maps NaN to the lower bound, and `write_audio` converts that `-1.0f` to `-32767`.

## What this PR does

- adds `ggml-patches/0018-metal-tensor-api-dynamic-k.patch`, a backport of upstream ggml `33c9ea5` (ggml-org/llama.cpp#27450). It clamps both operand views to `min(N_MM_NK_TOTAL, K - loop_k)` so the last chunk is described at its real size, and carries the upstream regression cases plus NanoCodec's `K = 1296` and an aligned `K = 1280` control.
- applies the patch series for `metal-*` presets in `scripts/configure.sh`, which it did not do before. Metal needs only 0018; `ggml-patches/README.md` says so and gives the criteria for dropping it.
- fixes two bash 4 constructs (`mapfile -d ''` and `${var^^}`) in `scripts/apply-ggml-patches.sh` and `scripts/configure.sh` that fail on macOS's `/bin/bash` 3.2.57. Without the first, `configure.sh` exits 0 while silently skipping every patch. The second aborts outright — on `main` today, `scripts/configure.sh metal-speech -DNEMO_SPEECH_BUILD_NMT=OFF` gives `${setting^^}: bad substitution`, which is why CI installs Homebrew bash to run these scripts. With this PR that step can go.

Advancing the submodule instead is a much bigger change: eleven of the existing patches do not apply on that commit. Drop 0018 when the submodule does move past it.

## Affected devices

Only where `has_tensor` is set, which the gate in `ggml-metal-device.m` limits to M5, M6, A19 and A20. M4 and earlier were never affected, and the set grows with each new chip.

## Verification

macOS 26.6.2, Apple M5, from clean clones of `main` (69d7fd4) and this branch. Synthesis is nondeterministic unless `--seed` is given, so every audio comparison below is seeded.

| | main | this branch |
|---|---|---|
| `metal-tts`, Metal, 3 voices + a long sentence | silent, 1 distinct sample value | speech, 8k–18k distinct values |
| `metal-tts`, CPU | speech | bit-for-bit identical to main |
| `metal-speech`, ASR and diarization, Metal and CPU | transcript and segments | identical, same 1.10 s per run |
| `metal-speech`, `ctest` | 7/7 | 7/7 |
| throughput | 1.77x Metal, 1.85x CPU | same |

The CPU row is the one that matters for risk: a Metal build now compiles patched `ggml.c` and `ggml-cpu`, and the output does not move.

Apple M4 Pro is unaffected and unchanged (10,367 vs 9,463 distinct values). `test-backend-ops -o MUL_MAT` goes from intermittent NaN failures to 1088/1088 across repeated runs. `GGML_METAL_TENSOR_DISABLE=1` restores audio on an unpatched build, which pins the fault to the tensor path and is a workaround for anyone on `v0.1.0`.

Not measured: M6, A19 and A20 rest on the device gate, not hardware. The bash fixes are checked on macOS bash 3.2.57 and bash 5.3, not on Linux, so GNU `tr` and `git` are unexercised.

## Two limits worth stating

Your CI cannot catch this bug. `macos-15` is a VM with a paravirtual GPU, so `has_tensor` is false there and the smoke test runs on CPU. Nothing here changes that, though the macOS job will now apply the series on every run, so the patches at least get checked against macOS.

The `test-backend-ops` cases this patch adds are never built here — no preset sets `GGML_BUILD_TESTS`. They mirror upstream and help anyone running ggml's own suite, but they are not enforced by this repo.

## Separate follow-up

A fully NaN decode still exits 0 with a valid file. A non-finite check before the float-to-int16 conversion would make this class of failure visible instead of silent. I will send that as its own PR.
