### PR TITLE
fix(tts): guard fused cached attention

### DIFF
--- a/src/tts/magpietts/CMakeLists.txt
+++ b/src/tts/magpietts/CMakeLists.txt
@@ -45,6 +45,9 @@ target_link_libraries(nemo_speech_tts PUBLIC
 # Stable C ABI (nemo_speech_tts_*) and the in-tree C++ API share one implementation
 # library. Aliases preserve existing target names without producing extra DSOs.
 target_compile_definitions(nemo_speech_tts PRIVATE NEMO_SPEECH_TTS_BUILD)
+if(NEMO_SPEECH_GGML_PATCHED)
+    target_compile_definitions(nemo_speech_tts PRIVATE NEMO_SPEECH_GGML_PATCHED=1)
+endif()
 set_target_properties(nemo_speech_tts PROPERTIES SOVERSION 1)
 if(UNIX AND NOT APPLE)
     target_link_options(nemo_speech_tts PRIVATE

--- a/src/tts/magpietts/decoder.cpp
+++ b/src/tts/magpietts/decoder.cpp
@@ -519,9 +519,18 @@ class PersistentDecoderModule final : public ggml_runtime::Module {
             ggml_tensor* v = split_heads(static_cast<size_t>(2 * tr.n_embd) * element);
             auto kv =
                 session->model_tensor_container->get_tensor_by_name(runtime_kv_name(layer_index));
+#if defined(NEMO_SPEECH_GGML_PATCHED)
             ggml_tensor* heads = ggml_fused_attn_cached(
                 ctx, q, k, v, nullptr, kv.tensor, slots.tensor, cache_meta.tensor, cache_len_,
                 1.0f / std::sqrt(static_cast<float>(d_head)), true);
+#else
+            (void)q;
+            (void)k;
+            (void)v;
+            (void)kv;
+            ggml_tensor* heads = nullptr;
+            throw std::runtime_error("Magpie persistent decoder requires patched ggml");
+#endif
             ggml_tensor* merged = ggml_reshape_2d(
                 ctx, ggml_permute(ctx, heads, 0, 2, 1, 3), tr.n_embd, kMagpieCfgLanes);
             x = ggml_add(ctx, residual, linear(ctx, layer.self_o, merged));
@@ -844,8 +853,9 @@ MagpieDecoder::evalCachedPair(
     const bool persistent_candidate =
         cuda_sample == nullptr && cond_hidden_out != nullptr && uncond_hidden_out != nullptr &&
         cond_cross_kv != nullptr && cond_cross_kv->validFor(model_, text_len) &&
-        model_.hparams.dec_kernel == 1 && magpietts_backend_is_cuda(model_.backend) &&
-        cond_kv.n_tokens > 0 && cond_kv.n_tokens == uncond_kv.n_tokens;
+        model_.hparams.dec_kernel == 1 &&
+        magpietts_fused_cached_attention_available(model_.backend) && cond_kv.n_tokens > 0 &&
+        cond_kv.n_tokens == uncond_kv.n_tokens;
     if (persistent_candidate) {
         try {
             if (persistent_runtime_ &&

--- a/src/tts/magpietts/lt.cpp
+++ b/src/tts/magpietts/lt.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <memory>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -565,7 +566,7 @@ bool
 LocalTransformerGraphBank::beginFrame(const magpietts_model& model, bool pair) {
     const auto& h = model.hparams;
     if (pair) {
-        if (magpietts_backend_is_cuda(model.backend)) {
+        if (magpietts_fused_cached_attention_available(model.backend)) {
             return pair_cuda_attention_cache.init(model, 2);
         }
         if (!cond_cache.init(
@@ -604,9 +605,20 @@ local_self_attention_cuda_cached_pair(
     ggml_tensor* q = split_heads(0);
     ggml_tensor* k = split_heads(static_cast<size_t>(n_embd) * element);
     ggml_tensor* v = split_heads(static_cast<size_t>(2 * n_embd) * element);
+#if defined(NEMO_SPEECH_GGML_PATCHED)
     ggml_tensor* heads = ggml_fused_attn_cached(
         ctx, q, k, v, nullptr, cache.layers[static_cast<size_t>(layer_index)], cache.slot_ids,
         cache_state, cache.n_ctx, 1.0f / std::sqrt(static_cast<float>(d_head)), true);
+#else
+    (void)q;
+    (void)k;
+    (void)v;
+    (void)cache;
+    (void)layer_index;
+    (void)cache_state;
+    ggml_tensor* heads = nullptr;
+    throw std::runtime_error("Magpie cached local attention requires patched ggml");
+#endif
     ggml_tensor* merged =
         ggml_reshape_2d(ctx, ggml_permute(ctx, heads, 0, 2, 1, 3), n_embd, kCfgLanes);
     return linear(ctx, layer.self_o, merged);
@@ -773,7 +785,8 @@ local_transformer_graph_init(
     graph.codebook_idx = codebook_idx;
     graph.seq_len = 1;
     graph.pair = pair;
-    const bool cuda_cached_attention = pair && magpietts_backend_is_cuda(model.backend);
+    const bool cuda_cached_attention =
+        pair && magpietts_fused_cached_attention_available(model.backend);
 
     if (cuda_cached_attention) {
         graph.cache_state =

--- a/src/tts/magpietts/model.cpp
+++ b/src/tts/magpietts/model.cpp
@@ -163,6 +163,16 @@ magpietts_backend_is_cuda(ggml_backend_t backend) {
 #endif
 }
 
+bool
+magpietts_fused_cached_attention_available(ggml_backend_t backend) {
+#if defined(NEMO_SPEECH_GGML_PATCHED)
+    return magpietts_backend_is_cuda(backend);
+#else
+    (void)backend;
+    return false;
+#endif
+}
+
 static constexpr size_t MAGPIETTS_PINNED_STAGING_MIN_BYTES = 4 * 1024;
 
 MagpiePinnedHostScratch::~MagpiePinnedHostScratch() {

--- a/src/tts/magpietts/model.h
+++ b/src/tts/magpietts/model.h
@@ -417,6 +417,8 @@ const char* magpietts_uma_mode_name(magpietts_uma_mode mode);
 bool parse_uma_mode(const std::string& value, magpietts_uma_mode& mode);
 
 bool magpietts_backend_is_cuda(ggml_backend_t backend);
+// ggml_fused_attn_cached comes from ggml-patches/0014 and has a CUDA kernel only.
+bool magpietts_fused_cached_attention_available(ggml_backend_t backend);
 
 std::vector<int32_t> parse_token_list(const std::string& text);
 std::string read_file(const std::string& path);


### PR DESCRIPTION
Fix for bug introduced in #17 that causes build failures on non-CUDA backends that don't apply patches. Reported in #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for speech synthesis across patched and unpatched builds.
  * Cached attention is now selected only when supported by the active backend.
  * Unsupported cached-attention configurations now fail clearly instead of attempting unavailable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->