### PR TITLE
fix(asr): link Abseil/Protobuf for SentencePiece on all platforms, not just Windows

### DIFF
--- a/src/asr/CMakeLists.txt
+++ b/src/asr/CMakeLists.txt
@@ -110,19 +110,24 @@ if(EXISTS "${_NEMO_SPEECH_SENTENCEPIECE_LICENSE_DIR}/LICENSE")
     install(DIRECTORY "${_NEMO_SPEECH_SENTENCEPIECE_LICENSE_DIR}/"
         DESTINATION "${NEMO_SPEECH_LICENSE_INSTALL_DIR}/third_party/sentencepiece")
 endif()
-# SentencePiece (vcpkg) uses absl::flat_hash_map + protobuf internally, but its
-# config target doesn't propagate those link deps. On Windows/vcpkg, add them
-# explicitly; elsewhere SentencePiece links its own deps (apt's -dev package).
-if(WIN32)
-    find_package(absl CONFIG QUIET)
-    if(absl_FOUND)
-        target_link_libraries(nemo_speech_asr PRIVATE
-            absl::flat_hash_map absl::flat_hash_set absl::strings absl::str_format absl::hash)
-    endif()
-    find_package(protobuf CONFIG QUIET)
-    if(TARGET protobuf::libprotobuf)
-        target_link_libraries(nemo_speech_asr PRIVATE protobuf::libprotobuf)
-    endif()
+# SentencePiece uses absl::Status (and, via vcpkg, absl::flat_hash_map +
+# protobuf) internally, but the imported target doesn't always propagate
+# those link deps. This was previously assumed Windows/vcpkg-only ("elsewhere
+# SentencePiece links its own deps"), but the same gap reproduces on macOS
+# against Homebrew's sentencepiece formula: its installed
+# sentencepiece_processor.h pulls in absl::Status, and libsentencepiece.dylib
+# doesn't re-export those symbols, so nemo_speech_asr fails to link with
+# undefined absl::Status symbols unless Abseil is linked explicitly here too.
+# Linking an already-found Abseil/Protobuf is harmless on platforms that
+# don't strictly need it, so don't special-case by platform at all.
+find_package(absl CONFIG QUIET)
+if(absl_FOUND)
+    target_link_libraries(nemo_speech_asr PRIVATE
+        absl::flat_hash_map absl::flat_hash_set absl::strings absl::str_format absl::hash absl::status)
+endif()
+find_package(protobuf CONFIG QUIET)
+if(TARGET protobuf::libprotobuf)
+    target_link_libraries(nemo_speech_asr PRIVATE protobuf::libprotobuf)
 endif()
 
 if(NEMO_SPEECH_WITH_FLASHLIGHT)


### PR DESCRIPTION
## Summary

`src/asr/CMakeLists.txt` links Abseil/Protobuf explicitly for SentencePiece's transitive dependencies only under `if(WIN32)`, on the assumption that "elsewhere SentencePiece links its own deps (apt's -dev package)".

That assumption doesn't hold for Homebrew's `sentencepiece` formula on macOS, which is the formula `docs/build.md` itself recommends (`brew install cmake ninja sentencepiece`). Building the `metal-server` preset from a clean checkout against it fails at the `libnemo_speech_asr.dylib` link step with undefined `absl::Status` symbols (`ToStringSlow`, `StatusRep::Unref`) — `sentencepiece_processor.h` uses `absl::Status`, but `libsentencepiece.dylib` doesn't re-export those symbols.

## Fix

Drop the `if(WIN32)` guard entirely rather than adding another platform special-case. `find_package(absl CONFIG QUIET)` / `find_package(protobuf CONFIG QUIET)` and linking whatever's found is a no-op on platforms where the SentencePiece package already links its own deps, and fixes the gap wherever it next reproduces (this is already the second platform it's hit).

## Test plan

- [x] Clean checkout at `v0.1.0`, submodules initialized (`ggml`, `llama.cpp`, `third_party/cpp-httplib`)
- [x] `brew install cmake ninja sentencepiece abseil` on macOS (Apple Silicon)
- [x] Before this change: `scripts/configure.sh metal-server` + `cmake --build --preset metal-server` fails linking `libnemo_speech_asr.dylib` with undefined `absl::Status` symbols
- [x] After this change: same build succeeds end to end
- [x] `cmake --install build/metal-server --prefix <prefix>`, then ran the resulting `nemo-speech` CLI against a synthesized test WAV — transcription output matches the input text exactly, confirming the fix doesn't just link but the ASR path works correctly