### PR TITLE
fix(ggml): guard the half_snake fusion against allocator buffer reuse

### DIFF
--- a/ggml-patches/0021-half-snake-fusion-aliasing-guard.patch
+++ b/ggml-patches/0021-half-snake-fusion-aliasing-guard.patch
@@ -1,0 +1,32 @@
+diff --git a/src/ggml-cuda/ggml-cuda.cu b/src/ggml-cuda/ggml-cuda.cu
+--- a/src/ggml-cuda/ggml-cuda.cu
++++ b/src/ggml-cuda/ggml-cuda.cu
+@@ -4162,6 +4162,28 @@
+         return 0;
+     }
+ 
++    // The graph allocator planned these buffers for the *unfused* sequence, in which the
++    // parent activation dies at the leaky_relu and its memory may be recycled for the
++    // concat output -- the unfused concat reads the materialised add/leaky_relu, not the
++    // parent. The fused kernel still reads the parent while writing the concat, so an
++    // output overlapping an input at a different offset races. Fuse only when the output
++    // misses both inputs entirely, or aliases them exactly (each thread then reads and
++    // writes one and the same address).
++    const char * dst_beg = (const char *) concat->data;
++    const char * dst_end = dst_beg + ggml_nbytes(concat);
++    const char * snk_beg = (const char *) x_snake->data;
++    const char * snk_end = snk_beg + ggml_nbytes(x_snake);
++    const char * lrl_beg = (const char *) view_l->data;
++    const char * lrl_end = lrl_beg + ggml_nbytes(view_l);
++
++    const bool disjoint = (snk_end <= dst_beg || dst_end <= snk_beg) &&
++                          (lrl_end <= dst_beg || dst_end <= lrl_beg);
++    const bool exact_inplace = dst_beg == snk_beg && lrl_beg == snk_end && dst_end == lrl_end;
++
++    if (!disjoint && !exact_inplace) {
++        return 0;
++    }
++
+     ggml_cuda_op_half_snake_fused(*cuda_ctx, x_snake, view_l, alpha, inv_b, lrelu, concat);
+     return 7;
+ }

--- a/ggml-patches/README.md
+++ b/ggml-patches/README.md
@@ -143,6 +143,29 @@ stock comparison therefore requires both a pristine ggml checkout and
   ReLU epilogues. This preserves the VoiceChat perception stem's native BF16
   behavior without adding standalone conversion kernels.
 
+- **0021-half-snake-fusion-aliasing-guard.patch** - fixes a read/write race in
+  the `half_snake` CUDA fusion added by 0007. The graph allocator plans buffers
+  for the *unfused* node sequence, in which the parent activation's last reader
+  is the `leaky_relu`, so its memory is free to be recycled for the `concat`
+  output -- the unfused `concat` reads the materialised add/leaky_relu, never
+  the parent. The fused kernel still reads that parent while writing the concat,
+  so wherever the allocator overlapped the two at different offsets, threads
+  clobbered input that other threads had not yet read.
+
+  Fusion is now skipped unless the output is disjoint from both inputs, or
+  aliases them exactly -- in which case every thread reads and writes a single
+  address and is safe. Because it depends on where the allocator happens to
+  place buffers, this corrupted some graphs and left others alone, which is why
+  the arithmetic always checked out in isolation.
+
+  On a GB300, a 3-frame NanoCodec decode against its own CPU reference. Before
+  the guard the corruption depends on allocator placement, so it is a
+  distribution, not a figure: 15 runs spanned 11.8 to 14.6 dB SNR, median 13.9.
+  With the guard the decode is stable at 39.5 dB, against 40.2 dB with fusion
+  disabled outright -- and the guard costs 0.8% throughput where disabling
+  fusion costs 26%. Covered by
+  `tests/cpp/tts/test_nanocodec_half_snake_fusion.cpp`.
+
 ## Regenerating after editing ggml
 
 Several patches touch the same ggml files, so regenerating a patch from the

--- a/tests/cpp/tts/CMakeLists.txt
+++ b/tests/cpp/tts/CMakeLists.txt
@@ -33,13 +33,20 @@ if(GGML_CUDA AND NEMO_SPEECH_GGML_PATCHED)
     add_test(NAME magpietts_cached_attention COMMAND test_magpietts_cached_attention)
 endif()
 
-add_executable(test_magpietts_asr test_magpietts_asr.cpp)
-target_link_libraries(test_magpietts_asr PRIVATE
-    tests_cpp_wer
-    nemo_speech_tts_magpietts
-    nemo_speech_tts_tokenizer
-    nemo_speech_asr
-)
+# Synthesizes with MagpieTTS and transcribes the result, so it needs both
+# pipelines. With NEMO_SPEECH_BUILD_ASR=OFF the nemo_speech_asr link name
+# resolves to nothing -- CMake takes an unknown target for a raw library and
+# says so only at link time -- so recognizer.h never reaches the include path
+# and the whole directory fails to compile.
+if(TARGET nemo_speech_asr)
+    add_executable(test_magpietts_asr test_magpietts_asr.cpp)
+    target_link_libraries(test_magpietts_asr PRIVATE
+        tests_cpp_wer
+        nemo_speech_tts_magpietts
+        nemo_speech_tts_tokenizer
+        nemo_speech_asr
+    )
+endif()
 
 # C ABI tests. tts_c_smoke is compiled as C (proves include/nemo_speech/tts.h
 # is valid C) and links the unified TTS library; tts_c_dlopen loads it at runtime.

--- a/tests/cpp/tts/CMakeLists.txt
+++ b/tests/cpp/tts/CMakeLists.txt
@@ -12,6 +12,21 @@ add_executable(test_magpietts_frame_stacking test_magpietts_frame_stacking.cpp)
 target_link_libraries(test_magpietts_frame_stacking PRIVATE nemo_speech_tts_magpietts)
 add_test(NAME magpietts_frame_stacking COMMAND test_magpietts_frame_stacking)
 
+# Needs a real graph and a real allocator, so it links ggml directly rather than
+# testing the kernel in isolation -- the bug it guards is invisible to a
+# kernel-level test. The fusion and its guard only exist in the patched ggml, so
+# against a stock submodule this would pass without exercising anything. Skips
+# itself (exit 77) without a GPU backend.
+if(GGML_CUDA AND NEMO_SPEECH_GGML_PATCHED)
+    add_executable(test_nanocodec_half_snake_fusion test_nanocodec_half_snake_fusion.cpp)
+    target_link_libraries(test_nanocodec_half_snake_fusion PRIVATE ggml)
+    add_test(
+        NAME nanocodec_half_snake_fusion
+        COMMAND test_nanocodec_half_snake_fusion)
+    set_tests_properties(nanocodec_half_snake_fusion PROPERTIES
+        SKIP_RETURN_CODE 77 TIMEOUT 120)
+endif()
+
 if(GGML_CUDA AND NEMO_SPEECH_GGML_PATCHED)
     add_executable(test_magpietts_cached_attention test_magpietts_cached_attention.cpp)
     target_link_libraries(test_magpietts_cached_attention PRIVATE nemo_speech_tts_magpietts)

--- a/tests/cpp/tts/test_nanocodec_half_snake_fusion.cpp
+++ b/tests/cpp/tts/test_nanocodec_half_snake_fusion.cpp
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression test for the half_snake CUDA fusion's aliasing guard.
+//
+// The fusion collapses the seven nodes NanoCodec's activation emits -- mul, sin,
+// sqr, mul, add, leaky_relu, concat -- into one kernel that reads the activation
+// input through two views and writes the concat output. The graph allocator
+// plans buffers for the *unfused* sequence, in which the input's last reader is
+// the leaky_relu, so the input's memory is free to be recycled for the concat
+// output. The fused kernel still reads the input while writing the concat, so
+// where the allocator overlapped them at a shifted offset, threads clobbered
+// input other threads had not read yet. It cost NanoCodec ~26 dB of SNR against
+// a CPU reference, and made the same codes decode differently on every run.
+//
+// Two things make this awkward to test, and shape what is below.
+//
+// The arithmetic is correct at every shape in isolation, so a kernel-level unit
+// test cannot see the bug -- it only appears once a real graph puts the output
+// on top of the input. And the *safe* overlap, where the concat exactly covers
+// its two input views end to end, is what a stock allocator produces for this
+// shape: every thread then reads and writes one address, which the guard
+// deliberately permits. A test that lets the allocator choose therefore passes
+// with the guard removed, which is worse than no test.
+//
+// So this test places the buffers itself: the concat output is put at a
+// deliberate byte offset inside the activation input, which is neither disjoint
+// nor an exact alias, and is exactly the case the guard must reject. The
+// unfused path is unaffected by that placement -- it materialises the snake and
+// leaky-relu halves into their own buffers first -- so the reference stays
+// valid.
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "ggml-backend.h"
+#include "ggml.h"
+
+namespace {
+
+// The fused kernel gives thread `idx` one read of x[idx] and one write of
+// dst[idx], and dst sits kOverlapShift bytes into x -- so thread idx clobbers
+// the input that thread idx + kOverlapShift/4 has yet to read. Whether that is
+// a *detectable* race depends on scheduling, and the sizes below are what make
+// it deterministic rather than a coin flip:
+//
+//   - The grid must exceed what the GPU can hold resident. At 256 threads per
+//     block these shapes are 8192 blocks, against the ~1200 a 148-SM GB300 can
+//     keep in flight. Blocks far enough apart therefore cannot overlap in time.
+//     A small tensor whose blocks are all co-resident fails only ~half the time
+//     -- the first version of this test was 512x64, i.e. 128 blocks, and caught
+//     the bug in 17 runs out of 30.
+//   - The shift must be many blocks, not many bytes, so that the writer has
+//     certainly retired before the reader launches. A quarter of the tensor is
+//     2048 blocks here, and still overlaps both input views partially, which is
+//     the case the guard has to reject.
+constexpr int64_t kLen = 8192;
+constexpr int64_t kChannels = 256;
+constexpr int64_t kSnakeChannels = 128;  // half snake, half leaky relu
+constexpr float kLeakySlope = 0.01f;
+constexpr size_t kOverlapShift = (size_t)kLen * (size_t)kChannels / 4 * sizeof(float);
+
+size_t
+align_up(size_t v, size_t a) {
+    return (v + a - 1) / a * a;
+}
+
+}  // namespace
+
+int
+main() {
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);
+    if (!backend) {
+        std::fprintf(stderr, "no GPU backend available; skipping\n");
+        return 77;  // ctest SKIP_RETURN_CODE
+    }
+
+    const size_t n = (size_t)kLen * (size_t)kChannels;
+    const size_t tensor_bytes = n * sizeof(float);
+
+    std::vector<float> host_in(n), host_alpha(kSnakeChannels), host_alpha_inv(kSnakeChannels);
+    // Straddle zero so the leaky-relu half exercises both branches: a clobbered
+    // input then shows up as a sign error, not a rounding one.
+    for (size_t i = 0; i < n; ++i) {
+        host_in[i] = std::sin((float)i * 0.037f) * 3.0f;
+    }
+    for (int64_t c = 0; c < kSnakeChannels; ++c) {
+        host_alpha[(size_t)c] = 0.5f + 0.01f * (float)c;
+        host_alpha_inv[(size_t)c] = 1.0f / host_alpha[(size_t)c];
+    }
+
+    ggml_init_params params{ggml_tensor_overhead() * 64 + ggml_graph_overhead(), nullptr, true};
+    ggml_context* ctx = ggml_init(params);
+    if (!ctx) {
+        std::fprintf(stderr, "FAIL: could not create a graph context\n");
+        return 1;
+    }
+
+    // One buffer, placed by hand. Layout: the activation input at 0, the concat
+    // output shifted into it, then everything else well clear of both.
+    const size_t align = 256;
+    const size_t scratch_base = align_up(tensor_bytes + kOverlapShift, align);
+    const size_t buf_bytes = scratch_base + 8 * align_up(tensor_bytes, align);
+    ggml_backend_buffer_t buf = ggml_backend_alloc_buffer(backend, buf_bytes);
+    if (!buf) {
+        std::fprintf(stderr, "FAIL: could not allocate a %zu byte backend buffer\n", buf_bytes);
+        return 1;
+    }
+    char* base = (char*)ggml_backend_buffer_get_base(buf);
+
+    size_t scratch = scratch_base;
+    auto place = [&](ggml_tensor* t, char* at) {
+        t->buffer = buf;
+        t->data = at;
+    };
+    auto place_scratch = [&](ggml_tensor* t) {
+        place(t, base + scratch);
+        scratch += align_up(ggml_nbytes(t), align);
+    };
+
+    // The activation input. Its views resolve their pointers from it at
+    // creation, so it has to be placed before they are built.
+    ggml_tensor* x = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, kLen, kChannels, 1);
+    ggml_set_name(x, "activation_input");
+    place(x, base);
+
+    ggml_tensor* alpha = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 1, kSnakeChannels, 1);
+    ggml_tensor* alpha_inv = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 1, kSnakeChannels, 1);
+    place_scratch(alpha);
+    place_scratch(alpha_inv);
+
+    ggml_tensor* x_snake = ggml_view_3d(ctx, x, kLen, kSnakeChannels, 1, x->nb[1], x->nb[2], 0);
+    ggml_tensor* x_lrelu = ggml_view_3d(
+        ctx, x, kLen, kChannels - kSnakeChannels, 1, x->nb[1], x->nb[2], kSnakeChannels * x->nb[1]);
+
+    ggml_tensor* ax = ggml_mul(ctx, x_snake, alpha);
+    ggml_tensor* periodic = ggml_mul(ctx, ggml_sqr(ctx, ggml_sin(ctx, ax)), alpha_inv);
+    ggml_tensor* snake_out = ggml_add(ctx, x_snake, periodic);
+    ggml_tensor* lrelu_out = ggml_leaky_relu(ctx, x_lrelu, kLeakySlope, false);
+    ggml_tensor* out = ggml_concat(ctx, snake_out, lrelu_out, 1);
+    ggml_set_name(out, "half_snake_out");
+    ggml_set_output(out);
+
+    ggml_cgraph* gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, out);
+
+    // Intermediates get their own space; only the concat is placed on top of the
+    // input, which is the condition under test.
+    for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
+        ggml_tensor* node = ggml_graph_node(gf, i);
+        if (node->data != nullptr) {
+            continue;
+        }
+        if (node == out) {
+            place(node, base + kOverlapShift);
+        } else {
+            place_scratch(node);
+        }
+    }
+
+    const char* in_beg = (const char*)x->data;
+    const char* in_end = in_beg + ggml_nbytes(x);
+    const char* out_beg = (const char*)out->data;
+    const char* out_end = out_beg + ggml_nbytes(out);
+    const bool overlaps = in_beg < out_end && out_beg < in_end;
+    const bool exact = out_beg == in_beg && out_end == in_end;
+    if (!overlaps || exact) {
+        std::fprintf(
+            stderr,
+            "FAIL: the test did not set up a shifted overlap (overlaps=%d exact=%d); "
+            "it would not exercise the guard\n",
+            (int)overlaps, (int)exact);
+        return 1;
+    }
+
+    ggml_backend_tensor_set(x, host_in.data(), 0, tensor_bytes);
+    ggml_backend_tensor_set(alpha, host_alpha.data(), 0, host_alpha.size() * sizeof(float));
+    ggml_backend_tensor_set(
+        alpha_inv, host_alpha_inv.data(), 0, host_alpha_inv.size() * sizeof(float));
+
+    if (ggml_backend_graph_compute(backend, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "FAIL: graph compute failed\n");
+        return 1;
+    }
+
+    std::vector<float> got(n);
+    ggml_backend_tensor_get(out, got.data(), 0, tensor_bytes);
+
+    double worst = 0.0;
+    size_t worst_at = 0;
+    for (int64_t c = 0; c < kChannels; ++c) {
+        for (int64_t i = 0; i < kLen; ++i) {
+            const size_t idx = (size_t)c * kLen + (size_t)i;
+            const double v = host_in[idx];
+            double want;
+            if (c < kSnakeChannels) {
+                const double s = std::sin(v * host_alpha[(size_t)c]);
+                want = v + s * s * host_alpha_inv[(size_t)c];
+            } else {
+                want = v >= 0.0 ? v : v * (double)kLeakySlope;
+            }
+            const double d = std::fabs((double)got[idx] - want);
+            if (d > worst) {
+                worst = d;
+                worst_at = idx;
+            }
+        }
+    }
+
+    ggml_backend_buffer_free(buf);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+
+    // Fused and unfused differ only in float ordering; a clobbered input is off
+    // by whole units, not ulps.
+    if (worst >= 1.0e-4) {
+        std::fprintf(
+            stderr,
+            "FAIL: half_snake output is wrong by %.6g at index %zu with the concat "
+            "output shifted %zu bytes into its input. The fusion ran on a partial "
+            "overlap, which it must refuse.\n",
+            worst, worst_at, kOverlapShift);
+        return 1;
+    }
+    std::fprintf(
+        stderr,
+        "OK: half_snake correct (max diff %.3g) with the output shifted %zu bytes "
+        "into its input\n",
+        worst, kOverlapShift);
+    return 0;
+}


### PR DESCRIPTION
The `half_snake` fusion in `0007-magpietts-nanocodec.patch` collapses seven nodes (`mul, sin, sqr, mul, add, leaky_relu, concat`) into one kernel. That kernel reads the parent activation through two views and writes the concat output.

The graph allocator plans buffers for the *unfused* sequence. There the parent's last reader is the `leaky_relu`, so the parent's memory is free to be recycled for the concat output: the unfused `concat` reads the materialised add/leaky_relu, never the parent. The fused kernel still reads that parent while writing the concat. Where the allocator overlapped the two at different offsets, threads clobbered input that other threads had not yet read.

Whether a graph is corrupted depends on where the allocator places buffers, so it hits some graphs and not others. That is why the kernel's arithmetic checks out in isolation.

## Fix

Fuse only when the output is disjoint from both inputs, or aliases them exactly. In the exact case every thread reads and writes one address, which is safe. Any other overlap falls back to the unfused path.

**This costs 0.8% codec throughput** (streaming RTFx 58.8 to 58.3 on a GB300). Disabling the fusion outright costs 26% (43.6), so the guard keeps almost all of it.

## Effect

Same text, same seed, greedy decoding, 100 decodes each. The fusion is in the codec, not the acoustic model, so every run produced byte-identical codes (`md5 4fd7631d…`). All variation below is the codec.

<img width="1440" height="800" alt="snr-distribution" src="https://github.com/user-attachments/assets/62339ef8-1330-4fd1-aa3a-3a44f660b191" />

Without the guard, the same input never decodes the same way twice, and the severity varies over a 20 dB range.

Audio samples:
* [fixed-1.wav](https://github.com/user-attachments/files/31849262/fixed-1.wav)
* [buggy-1.wav](https://github.com/user-attachments/files/31849263/buggy-1.wav)

Severity depends on configuration. It sounds like faint/astationary background noise and occasional 'pops'. Narrow codec chunks are worst (15 runs each, each against its own CPU reference). These are the figures the patch notes now quote — because the corruption tracks allocator placement it is a distribution, not a single number:

| config | min / median / max |
|---|---|
| `codec-chunk 3` | 11.8 / 13.9 / 14.6 dB |
| `codec-chunk 32` | 17.3 / 21.8 / 26.9 dB |

## Test

`tests/cpp/tts/test_nanocodec_half_snake_fusion.cpp`, registered in ctest, skips with exit 77 without a GPU.

Notes:
- The arithmetic is correct at every shape in isolation, so a kernel-level test cannot catch this.
- The *safe* overlap, where the concat exactly covers its two input views, is what a stock allocator produces for this shape. A test that lets the allocator choose passes even with the guard removed. My first version did.

The test therefore places the buffers manually, putting the concat output a quarter of the tensor into the activation input. That is neither disjoint nor an exact alias, which is the case the guard must reject.

The shapes matter as much as the placement, which is what the latest revision fixes. Thread `idx` reads `x[idx]` and writes `dst[idx]`, so it clobbers input a later thread has yet to read — but that only *shows* if the write retires before the read. At the original 512x64 the whole grid is 128 blocks of 256 threads, all resident at once on a 148-SM GB300, and the ordering is a coin flip: **the test caught the bug in only 17 runs out of 30.** Sized so the grid (8192 blocks) far exceeds residency and the shift is 2048 blocks rather than 1 KiB, the writer has provably retired first:

| | guard reverted | guard applied |
|---|---|---|
| 30 runs | 30 fail | 30 pass |

Verified on this branch by reverting and re-applying the patch against the built tree.

## Also included

`tests/cpp/tts/CMakeLists.txt` guards `test_magpietts_asr` on `TARGET nemo_speech_asr`. That test needs both pipelines, and with `NEMO_SPEECH_BUILD_ASR=OFF` the `nemo_speech_asr` link name resolves to nothing, so `recognizer.h` never reaches the include path and the whole `tests/cpp/tts` directory fails to compile.

It is bundled here because the new fusion test lives in that directory and cannot be built in an ASR-off configuration without it. With the guard the tests target builds clean and ctest goes from three unbuildable entries to 9/9.


## Review updates

- Renamed the patch to `0021-half-snake-fusion-aliasing-guard.patch` and rebased onto current `main`, which has since taken `0018`-`0020`. The full series applies to the pinned submodule in order.
- Gated the fusion test on `NEMO_SPEECH_GGML_PATCHED` as well as `GGML_CUDA`. The fusion and its guard only exist in the patched ggml, so against a stock submodule the test passed without exercising anything.
- Replaced the single "13.5 dB" figure in the patch notes with the 15-run distribution above, since a lone number misrepresents a fault that varies run to run.
- Resized the test so it fails deterministically without the guard (see **Test**).

Verified on a GB300: `cuda-tts` and `cpu-tts`, both with `-DNEMO_SPEECH_BUILD_TESTS=ON`, build clean and pass 9/9 and 7/7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA speech-processing reliability by preventing unsafe fused operations when input and output memory regions partially overlap.
  - Preserved supported in-place processing while avoiding potential read/write conflicts.

- **Tests**
  - Added regression coverage for partially overlapping buffers, including numerical comparison against CPU results.
  - Improved test configuration for environments without a CUDA backend.

- **Documentation**
  - Added performance and signal-quality measurements for the updated processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
