### PR TITLE
fix(tts): reject decoded audio that cannot be speech

### DIFF
--- a/src/tts/magpietts/magpietts.cpp
+++ b/src/tts/magpietts/magpietts.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -496,6 +497,30 @@ stream_run_metrics::inter_chunk_min_value_ms() const {
     return e2e.inter_event_min_value_ms();
 }
 
+bool
+magpie_require_valid_audio(const std::vector<float>& audio) {
+    if (audio.empty()) {
+        // A chunk with no frames decodes to no samples; nothing to reject.
+        return true;
+    }
+    const float first = audio.front();
+    bool uniform = true;
+    for (float x : audio) {
+        if (!std::isfinite(x)) {
+            fprintf(stderr, "codec produced audio that is not finite (NaN or infinity)\n");
+            return false;
+        }
+        uniform = uniform && (x == first);
+    }
+    if (uniform && (first == 1.0f || first == -1.0f)) {
+        fprintf(
+            stderr, "codec produced %zu audio samples pinned to a single full-scale value\n",
+            audio.size());
+        return false;
+    }
+    return true;
+}
+
 struct stream_audio_outputs {
     int sample_rate = 0;
     uint64_t samples_written = 0;
@@ -677,6 +702,10 @@ decode_and_stream_chunk(
         decoded = decoder.decode(codec_frames, threads, audio);
     }
     if (!decoded) {
+        return false;
+    }
+    // Before overlap-add, which blends an invalid chunk into a valid one.
+    if (!magpie_require_valid_audio(audio)) {
         return false;
     }
     const int64_t decoded_us = ggml_time_us();

--- a/src/tts/magpietts/magpietts.h
+++ b/src/tts/magpietts/magpietts.h
@@ -176,6 +176,9 @@ bool magpie_stream_runtime_synthesize(
     const std::vector<int32_t>& tokens, const magpie_pcm_callback& pcm_callback,
     stream_run_metrics& metrics);
 
+// Logs and returns false when a decoded chunk cannot be speech.
+bool magpie_require_valid_audio(const std::vector<float>& audio);
+
 const char* magpie_longform_mode_name(magpie_longform_mode mode);
 bool parse_magpie_longform_mode(const std::string& value, magpie_longform_mode& mode);
 

--- a/tests/cpp/tts/CMakeLists.txt
+++ b/tests/cpp/tts/CMakeLists.txt
@@ -12,6 +12,10 @@ add_executable(test_magpietts_frame_stacking test_magpietts_frame_stacking.cpp)
 target_link_libraries(test_magpietts_frame_stacking PRIVATE nemo_speech_tts_magpietts)
 add_test(NAME magpietts_frame_stacking COMMAND test_magpietts_frame_stacking)
 
+add_executable(test_magpietts_audio_sanity test_magpietts_audio_sanity.cpp)
+target_link_libraries(test_magpietts_audio_sanity PRIVATE nemo_speech_tts_magpietts)
+add_test(NAME magpietts_audio_sanity COMMAND test_magpietts_audio_sanity)
+
 if(GGML_CUDA AND NEMO_SPEECH_GGML_PATCHED)
     add_executable(test_magpietts_cached_attention test_magpietts_cached_attention.cpp)
     target_link_libraries(test_magpietts_cached_attention PRIVATE nemo_speech_tts_magpietts)

--- a/tests/cpp/tts/test_magpietts_audio_sanity.cpp
+++ b/tests/cpp/tts/test_magpietts_audio_sanity.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include <unistd.h>
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+#include "tts/magpietts/audio_pp.h"
+#include "tts/magpietts/magpietts.h"
+
+namespace tts = nemo_speech::tts;
+
+static int failures = 0;
+
+// The function under test logs its own rejection, which would make a passing
+// run look like a failing one. Keep that output out of the test transcript.
+static bool
+valid_quietly(const std::vector<float>& audio) {
+    std::fflush(stderr);
+    const int saved = dup(STDERR_FILENO);
+    FILE* devnull = std::fopen("/dev/null", "w");
+    if (devnull != nullptr) {
+        dup2(fileno(devnull), STDERR_FILENO);
+    }
+    const bool ok = tts::magpie_require_valid_audio(audio);
+    std::fflush(stderr);
+    dup2(saved, STDERR_FILENO);
+    close(saved);
+    if (devnull != nullptr) {
+        std::fclose(devnull);
+    }
+    return ok;
+}
+
+static void
+expect(const char* name, const std::vector<float>& audio, bool want_rejected) {
+    if (valid_quietly(audio) == want_rejected) {
+        std::fprintf(stderr, "%s: expected %s\n", name, want_rejected ? "rejection" : "acceptance");
+        ++failures;
+    }
+}
+
+int
+main() {
+    const float nan_value = std::numeric_limits<float>::quiet_NaN();
+    const float inf_value = std::numeric_limits<float>::infinity();
+
+    expect("speech", {0.0f, 0.31f, -0.22f, 0.75f, -0.61f}, false);
+    expect("quiet", {0.0f, 0.0f, 0.0f, 0.0f}, false);
+    expect("digital silence", std::vector<float>(4096, 0.0f), false);
+    expect("clipped but varying", {1.0f, 1.0f, 0.42f, -1.0f, -1.0f}, false);
+    expect("single sample", {0.5f}, false);
+    expect("empty", {}, false);
+
+    // Loud and clipped audio stays valid: a saturated waveform still crosses zero.
+    {
+        std::vector<float> clipped(4096);
+        for (size_t i = 0; i < clipped.size(); ++i) {
+            const float x = 4.0f * std::sin(0.03f * (float)i);
+            clipped[i] = x > 1.0f ? 1.0f : (x < -1.0f ? -1.0f : x);
+        }
+        expect("hard-clipped loud speech", clipped, false);
+        std::vector<float> square(4096);
+        for (size_t i = 0; i < square.size(); ++i) {
+            square[i] = (i % 2 == 0) ? 1.0f : -1.0f;
+        }
+        expect("fully saturated square wave", square, false);
+    }
+
+    expect("all negative full scale", std::vector<float>(1024, -1.0f), true);
+    expect("all positive full scale", std::vector<float>(1024, 1.0f), true);
+    expect("one sample at full scale", {-1.0f}, true);
+
+    expect("nan", {0.2f, nan_value, 0.4f}, true);
+    expect("nan at end", {0.2f, 0.4f, nan_value}, true);
+    expect("positive infinity", {0.2f, inf_value}, true);
+    expect("negative infinity", {0.2f, -inf_value}, true);
+    expect("all nan", std::vector<float>(64, nan_value), true);
+
+    expect("uniform mid scale", std::vector<float>(1024, 0.5f), false);
+    expect("uniform near full scale", std::vector<float>(1024, 0.999f), false);
+
+    // Why the check runs on the decoded chunk: overlap-add crossfades an invalid
+    // chunk against its neighbour, and it no longer looks uniform afterwards.
+    {
+        const std::vector<float> invalid(1024, -1.0f);
+        std::vector<float> valid(1024);
+        for (size_t i = 0; i < valid.size(); ++i) {
+            valid[i] = 0.5f * std::sin(0.05f * (float)i);
+        }
+        expect("decoded chunk, before post-processing", invalid, true);
+
+        tts::AudioPostProcessor pp(
+            /*samples_per_frame=*/128, /*future_frames=*/0,
+            /*window_samples=*/64);
+        std::vector<std::vector<float>> written;
+        auto sink = [&](const std::vector<float>& chunk) {
+            written.push_back(chunk);
+            return true;
+        };
+        const bool wrote_invalid = pp.writeDecodedAudio(invalid, /*history_frames=*/2, false, sink);
+        const bool wrote_valid = pp.writeDecodedAudio(valid, /*history_frames=*/2, false, sink);
+        const bool flushed = pp.flush(sink);
+        if (!wrote_invalid || !wrote_valid || !flushed) {
+            std::fprintf(
+                stderr, "crossfade case: post-processor write failed (%d %d %d)\n",
+                (int)wrote_invalid, (int)wrote_valid, (int)flushed);
+            ++failures;
+        }
+
+        if (written.empty()) {
+            std::fprintf(stderr, "crossfade case: post-processor produced no chunks\n");
+            ++failures;
+        } else {
+            size_t full_scale = 0;
+            for (float x : written[0]) {
+                full_scale += (x == -1.0f) ? 1 : 0;
+            }
+            if (full_scale * 2 <= written[0].size()) {
+                std::fprintf(
+                    stderr, "crossfade case: expected a mostly full-scale chunk, got %zu of %zu\n",
+                    full_scale, written[0].size());
+                ++failures;
+            }
+            expect("same chunk, after overlap-add", written[0], false);
+        }
+    }
+
+    if (failures != 0) {
+        std::fprintf(stderr, "%d audio sanity case(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("audio sanity: all cases passed\n");
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #19, which @pskrunner14 suggested opening separately in #20.

## What happens today

A numerical failure in the decoder or codec is written out as a valid WAV that plays as silence: exit 0, plausible duration, normal realtime factor, nothing in the logs. That turns a clear bug into an invisible one, and it is why the M5 fault in #19 went unnoticed.

## What this does

Rejects a decoded chunk that cannot be speech and fails the synthesis, rather than writing it.

Two conditions trigger a rejection, because one is not enough. The first is a non-finite sample, the obvious one. But `ggml_clamp(x, -1, 1)` is the last op of the NanoCodec graph and Metal's `clamp` maps NaN onto the lower bound, so a fully NaN decode arrives as a finite `-1.0f` that `write_audio` converts to a legal `-32767`. An `isfinite` check alone never fires on it. The second condition catches exactly that case: a chunk pinned bit-identically to a clamp bound.

Loud audio is unaffected: every sample has to be the *same* full-scale value, and even a fully saturated waveform crosses zero. Constants that are not full scale stay valid, so digital silence passes.

The check runs on the decoded chunk, before overlap-add crossfades it against its neighbour and it stops being recognisable.

## Verification

Apple M5, macOS 26.6.2, `metal-tts` and `metal-speech`.

- On unpatched ggml, where the #19 fault is live, synthesis now stops on the first chunk and writes no file. With #20 applied, and on CPU, output is unchanged.
- 216 real syntheses (12 texts x 3 voices x 3 seeds, CPU and Metal) produced byte-identical audio with and without the check: 0 rejected, 0 mismatches.
- `--cfg-scale` to 30 and `--temperature` to 3.0 on a shouting prompt: peak sample 22,489 of 32,767, zero full-scale samples.
- `ctest` 8/8 including the new test, `pre-commit run --all-files` clean.

Cost is 0.3 us per 1024-sample streaming chunk and 18 us for a 2.7 s utterance, against roughly 2.6 s to synthesize it. End-to-end timing over 8 interleaved runs stayed inside noise.

## Limitations

- The guard has no partial mode: it passes a chunk through untouched or fails the run. It cannot drop audio.
- The unit test reproduces the overlap-add case but does not guard the production call site; removing that call still leaves the test passing.
- Library and C API callers see only `MagpieTTS synthesis failed`. The reason goes to stderr, as it does for every failure on that path.
- An empty chunk is a legitimate decode result and is accepted. I could not produce one in normal synthesis, so that path is unexercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech audio validation to detect invalid decoded output, including non-finite samples and unusable constant full-scale audio.
  * Prevented invalid audio from continuing through processing, improving playback reliability.
  * Preserved support for valid speech, silence, clipped waveforms, and empty audio where appropriate.

* **Tests**
  * Added coverage for audio validation and post-processing behavior across valid and invalid waveform cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->