### PR TITLE
fix(tests): build the MagpieTTS ASR test only when ASR is enabled

### DIFF
--- a/tests/cpp/tts/CMakeLists.txt
+++ b/tests/cpp/tts/CMakeLists.txt
@@ -18,13 +18,15 @@ if(GGML_CUDA AND NEMO_SPEECH_GGML_PATCHED)
     add_test(NAME magpietts_cached_attention COMMAND test_magpietts_cached_attention)
 endif()
 
-add_executable(test_magpietts_asr test_magpietts_asr.cpp)
-target_link_libraries(test_magpietts_asr PRIVATE
-    tests_cpp_wer
-    nemo_speech_tts_magpietts
-    nemo_speech_tts_tokenizer
-    nemo_speech_asr
-)
+if(NEMO_SPEECH_BUILD_ASR)
+    add_executable(test_magpietts_asr test_magpietts_asr.cpp)
+    target_link_libraries(test_magpietts_asr PRIVATE
+        tests_cpp_wer
+        nemo_speech_tts_magpietts
+        nemo_speech_tts_tokenizer
+        nemo_speech_asr
+    )
+endif()
 
 # C ABI tests. tts_c_smoke is compiled as C (proves include/nemo_speech/tts.h
 # is valid C) and links the unified TTS library; tts_c_dlopen loads it at runtime.


### PR DESCRIPTION
Fixes #30.

`test_magpietts_asr` links `nemo_speech_asr` and `tests_cpp_wer`, neither of which exists in a TTS-only build, but it was added unconditionally. Guard it on `NEMO_SPEECH_BUILD_ASR`, matching `test_magpietts_cached_attention` above it.

Verified on `main` (69d7fd4):

- `scripts/configure.sh cpu-tts -DNEMO_SPEECH_BUILD_TESTS=ON` then `cmake --build` — fails before this change, builds and passes `ctest` after.
- `scripts/configure.sh cpu-speech -DNEMO_SPEECH_BUILD_TESTS=ON` still builds `test_magpietts_asr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Speech recognition test components are now included only when speech recognition support is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->