### PR TITLE
perf(tts): stop emitting no-op contiguity and cast copies

### DIFF
--- a/src/tts/magpietts/decoder.cpp
+++ b/src/tts/magpietts/decoder.cpp
@@ -1061,7 +1061,7 @@ decoder_eval_impl(
     ggml_tensor* dec_out = transformer_forward(
         ctx, model.decoder, dec_in, pos, cond, attn_prior,
         collect_alignment ? &alignment_outputs : nullptr);
-    dec_out = ggml_cont(ctx, ggml_cast(ctx, dec_out, GGML_TYPE_F32));
+    dec_out = as_f32_contig(ctx, dec_out);
     ggml_set_name(dec_out, "magpietts_decoder_out");
     ggml_set_output(dec_out);
 
@@ -1069,7 +1069,7 @@ decoder_eval_impl(
     ggml_tensor* logits = nullptr;
     if (compute_logits) {
         logits = linear(ctx, model.final_proj_w, dec_out, model.final_proj_b);
-        logits = ggml_cont(ctx, ggml_cast(ctx, logits, GGML_TYPE_F32));
+        logits = as_f32_contig(ctx, logits);
         ggml_set_name(logits, "magpietts_decoder_logits");
         ggml_set_output(logits);
     }
@@ -1215,7 +1215,7 @@ decoder_eval_pair_impl(
     ggml_tensor* dec_out_cond = transformer_forward(
         ctx, model.decoder, dec_in_cond, pos, text, attn_prior,
         collect_alignment ? &alignment_outputs : nullptr);
-    dec_out_cond = ggml_cont(ctx, ggml_cast(ctx, dec_out_cond, GGML_TYPE_F32));
+    dec_out_cond = as_f32_contig(ctx, dec_out_cond);
     ggml_set_name(dec_out_cond, "magpietts_decoder_out_cond");
     ggml_set_output(dec_out_cond);
 
@@ -1224,21 +1224,21 @@ decoder_eval_pair_impl(
     ggml_tensor* logits_cond = nullptr;
     if (compute_logits) {
         logits_cond = linear(ctx, model.final_proj_w, dec_out_cond, model.final_proj_b);
-        logits_cond = ggml_cont(ctx, ggml_cast(ctx, logits_cond, GGML_TYPE_F32));
+        logits_cond = as_f32_contig(ctx, logits_cond);
         ggml_set_name(logits_cond, "magpietts_decoder_logits_cond");
         ggml_set_output(logits_cond);
     }
 
     ggml_tensor* dec_out_uncond =
         transformer_forward(ctx, model.decoder, dec_in_uncond, pos, nullptr);
-    dec_out_uncond = ggml_cont(ctx, ggml_cast(ctx, dec_out_uncond, GGML_TYPE_F32));
+    dec_out_uncond = as_f32_contig(ctx, dec_out_uncond);
     ggml_set_name(dec_out_uncond, "magpietts_decoder_out_uncond");
     ggml_set_output(dec_out_uncond);
 
     ggml_tensor* logits_uncond = nullptr;
     if (compute_logits) {
         logits_uncond = linear(ctx, model.final_proj_w, dec_out_uncond, model.final_proj_b);
-        logits_uncond = ggml_cont(ctx, ggml_cast(ctx, logits_uncond, GGML_TYPE_F32));
+        logits_uncond = as_f32_contig(ctx, logits_uncond);
         ggml_set_name(logits_uncond, "magpietts_decoder_logits_uncond");
         ggml_set_output(logits_uncond);
     }
@@ -1454,7 +1454,7 @@ decoder_eval_cached_impl(
     ggml_tensor* dec_out = transformer_forward_cached(
         ctx, gf, model.decoder, dec_in, pos, cond, kv_state, conditional ? cross_kv : nullptr,
         n_past, attn_prior, collect_alignment ? &alignment_outputs : nullptr);
-    dec_out = ggml_cont(ctx, ggml_cast(ctx, dec_out, GGML_TYPE_F32));
+    dec_out = as_f32_contig(ctx, dec_out);
     ggml_set_name(dec_out, "magpietts_decoder_out_cached");
     ggml_set_output(dec_out);
 
@@ -1462,7 +1462,7 @@ decoder_eval_cached_impl(
     ggml_tensor* logits = nullptr;
     if (compute_logits) {
         logits = linear(ctx, model.final_proj_w, dec_out, model.final_proj_b);
-        logits = ggml_cont(ctx, ggml_cast(ctx, logits, GGML_TYPE_F32));
+        logits = as_f32_contig(ctx, logits);
         ggml_set_name(logits, "magpietts_decoder_logits_cached");
         ggml_set_output(logits);
         ggml_build_forward_expand(gf, logits);
@@ -1677,7 +1677,7 @@ decoder_eval_cached_pair_impl(
     ggml_tensor* dec_out_cond = transformer_forward_cached(
         ctx, gf, model.decoder, dec_in_cond, pos, text, cond_kv, cond_cross_kv, n_past, attn_prior,
         collect_alignment ? &alignment_outputs : nullptr);
-    dec_out_cond = ggml_cont(ctx, ggml_cast(ctx, dec_out_cond, GGML_TYPE_F32));
+    dec_out_cond = as_f32_contig(ctx, dec_out_cond);
     ggml_set_name(dec_out_cond, "magpietts_decoder_out_cond_cached");
     ggml_set_output(dec_out_cond);
 
@@ -1686,21 +1686,21 @@ decoder_eval_cached_pair_impl(
     ggml_tensor* logits_cond = nullptr;
     if (compute_logits) {
         logits_cond = linear(ctx, model.final_proj_w, dec_out_cond, model.final_proj_b);
-        logits_cond = ggml_cont(ctx, ggml_cast(ctx, logits_cond, GGML_TYPE_F32));
+        logits_cond = as_f32_contig(ctx, logits_cond);
         ggml_set_name(logits_cond, "magpietts_decoder_logits_cond_cached");
         ggml_set_output(logits_cond);
     }
 
     ggml_tensor* dec_out_uncond = transformer_forward_cached(
         ctx, gf, model.decoder, dec_in_uncond, pos, nullptr, uncond_kv, nullptr, n_past);
-    dec_out_uncond = ggml_cont(ctx, ggml_cast(ctx, dec_out_uncond, GGML_TYPE_F32));
+    dec_out_uncond = as_f32_contig(ctx, dec_out_uncond);
     ggml_set_name(dec_out_uncond, "magpietts_decoder_out_uncond_cached");
     ggml_set_output(dec_out_uncond);
 
     ggml_tensor* logits_uncond = nullptr;
     if (compute_logits) {
         logits_uncond = linear(ctx, model.final_proj_w, dec_out_uncond, model.final_proj_b);
-        logits_uncond = ggml_cont(ctx, ggml_cast(ctx, logits_uncond, GGML_TYPE_F32));
+        logits_uncond = as_f32_contig(ctx, logits_uncond);
         ggml_set_name(logits_uncond, "magpietts_decoder_logits_uncond_cached");
         ggml_set_output(logits_uncond);
     }

--- a/src/tts/magpietts/graph.h
+++ b/src/tts/magpietts/graph.h
@@ -13,10 +13,12 @@ class DecoderCrossKvCache;
 // that computes nothing, and ggml_cast to the type a tensor already has is the
 // same copy. Both show up per decode step, per layer, per column. A reshape of
 // a contiguous tensor is the identical view for free.
-inline ggml_tensor* as_contig(ggml_context* ctx, ggml_tensor* t) {
+inline ggml_tensor*
+as_contig(ggml_context* ctx, ggml_tensor* t) {
     return ggml_is_contiguous(t) ? t : ggml_cont(ctx, t);
 }
-inline ggml_tensor* as_contig_2d(ggml_context* ctx, ggml_tensor* t, int64_t ne0, int64_t ne1) {
+inline ggml_tensor*
+as_contig_2d(ggml_context* ctx, ggml_tensor* t, int64_t ne0, int64_t ne1) {
     return ggml_is_contiguous(t) ? ggml_reshape_2d(ctx, t, ne0, ne1)
                                  : ggml_cont_2d(ctx, t, ne0, ne1);
 }
@@ -27,7 +29,8 @@ as_contig_3d(ggml_context* ctx, ggml_tensor* t, int64_t ne0, int64_t ne1, int64_
 }
 // The graph's read-back tensors want F32 and contiguous; when they already are,
 // asking for it again costs a copy of the whole tensor every step.
-inline ggml_tensor* as_f32_contig(ggml_context* ctx, ggml_tensor* t) {
+inline ggml_tensor*
+as_f32_contig(ggml_context* ctx, ggml_tensor* t) {
     if (t->type != GGML_TYPE_F32) {
         t = ggml_cast(ctx, t, GGML_TYPE_F32);
     }

--- a/src/tts/magpietts/graph.h
+++ b/src/tts/magpietts/graph.h
@@ -9,6 +9,31 @@ namespace nemo_speech::tts {
 class DecoderKvCache;
 class DecoderCrossKvCache;
 
+// ggml_cont on an already-contiguous tensor is a full device-to-device copy
+// that computes nothing, and ggml_cast to the type a tensor already has is the
+// same copy. Both show up per decode step, per layer, per column. A reshape of
+// a contiguous tensor is the identical view for free.
+inline ggml_tensor* as_contig(ggml_context* ctx, ggml_tensor* t) {
+    return ggml_is_contiguous(t) ? t : ggml_cont(ctx, t);
+}
+inline ggml_tensor* as_contig_2d(ggml_context* ctx, ggml_tensor* t, int64_t ne0, int64_t ne1) {
+    return ggml_is_contiguous(t) ? ggml_reshape_2d(ctx, t, ne0, ne1)
+                                 : ggml_cont_2d(ctx, t, ne0, ne1);
+}
+inline ggml_tensor*
+as_contig_3d(ggml_context* ctx, ggml_tensor* t, int64_t ne0, int64_t ne1, int64_t ne2) {
+    return ggml_is_contiguous(t) ? ggml_reshape_3d(ctx, t, ne0, ne1, ne2)
+                                 : ggml_cont_3d(ctx, t, ne0, ne1, ne2);
+}
+// The graph's read-back tensors want F32 and contiguous; when they already are,
+// asking for it again costs a copy of the whole tensor every step.
+inline ggml_tensor* as_f32_contig(ggml_context* ctx, ggml_tensor* t) {
+    if (t->type != GGML_TYPE_F32) {
+        t = ggml_cast(ctx, t, GGML_TYPE_F32);
+    }
+    return as_contig(ctx, t);
+}
+
 ggml_tensor* layer_norm(ggml_context* ctx, ggml_tensor* x, ggml_tensor* weight);
 ggml_tensor* linear(ggml_context* ctx, ggml_tensor* w, ggml_tensor* x, ggml_tensor* b = nullptr);
 ggml_tensor* causal_conv1d(

--- a/src/tts/magpietts/lt.cpp
+++ b/src/tts/magpietts/lt.cpp
@@ -628,7 +628,7 @@ static ggml_tensor*
 local_transformer_forward_cached_fixed_pos(
     ggml_context* ctx, ggml_cgraph* gf, const magpietts_transformer& tr, ggml_tensor* x,
     ggml_tensor* pos_emb, DecoderKvCache& cache, int n_past) {
-    pos_emb = ggml_cont(ctx, ggml_cast(ctx, pos_emb, GGML_TYPE_F32));
+    pos_emb = as_f32_contig(ctx, pos_emb);
     x = ggml_add(ctx, x, pos_emb);
 
     for (int il = 0; il < (int)tr.layers.size(); ++il) {
@@ -729,7 +729,7 @@ local_transformer_forward_cached_pair_fixed_pos(
     ggml_tensor* pos_emb, DecoderKvCache& cond_cache, DecoderKvCache& uncond_cache,
     LocalTransformerCudaAttentionCache* cuda_attention_cache, ggml_tensor* cache_state,
     int n_past) {
-    pos_emb = ggml_cont(ctx, ggml_cast(ctx, pos_emb, GGML_TYPE_F32));
+    pos_emb = as_f32_contig(ctx, pos_emb);
     x = ggml_add(ctx, x, pos_emb);
     for (int il = 0; il < static_cast<int>(tr.layers.size()); ++il) {
         const magpietts_layer& layer = tr.layers[static_cast<size_t>(il)];
@@ -853,7 +853,7 @@ local_transformer_graph_init(
                 graph.cache_state, codebook_idx);
             ggml_tensor* logits_pair = linear(
                 graph.ctx, model.lt_out_w[codebook_idx], out_pair, model.lt_out_b[codebook_idx]);
-            logits_pair = ggml_cont(graph.ctx, ggml_cast(graph.ctx, logits_pair, GGML_TYPE_F32));
+            logits_pair = as_f32_contig(graph.ctx, logits_pair);
             graph.logits_cond =
                 ggml_view_2d(graph.ctx, logits_pair, h.audio_vocab_size, 1, logits_pair->nb[1], 0);
             graph.logits_uncond = ggml_view_2d(
@@ -875,7 +875,7 @@ local_transformer_graph_init(
             graph.logits_cond = linear(
                 graph.ctx, model.lt_out_w[codebook_idx], out_cond, model.lt_out_b[codebook_idx]);
             graph.logits_cond =
-                ggml_cont(graph.ctx, ggml_cast(graph.ctx, graph.logits_cond, GGML_TYPE_F32));
+                as_f32_contig(graph.ctx, graph.logits_cond);
             ggml_set_name(graph.logits_cond, "magpietts_local_transformer_logits");
             ggml_set_output(graph.logits_cond);
             ggml_build_forward_expand(graph.gf, graph.logits_cond);

--- a/src/tts/magpietts/lt.cpp
+++ b/src/tts/magpietts/lt.cpp
@@ -874,8 +874,7 @@ local_transformer_graph_init(
                 codebook_idx);
             graph.logits_cond = linear(
                 graph.ctx, model.lt_out_w[codebook_idx], out_cond, model.lt_out_b[codebook_idx]);
-            graph.logits_cond =
-                as_f32_contig(graph.ctx, graph.logits_cond);
+            graph.logits_cond = as_f32_contig(graph.ctx, graph.logits_cond);
             ggml_set_name(graph.logits_cond, "magpietts_local_transformer_logits");
             ggml_set_output(graph.logits_cond);
             ggml_build_forward_expand(graph.gf, graph.logits_cond);

--- a/src/tts/magpietts/model.cpp
+++ b/src/tts/magpietts/model.cpp
@@ -1072,17 +1072,17 @@ self_attention(
     ggml_tensor* vcur = ggml_view_2d(
         ctx, qkv, n_embd, n_tok, qkv->nb[1], (size_t)ggml_element_size(qkv) * n_embd * 2);
 
-    ggml_tensor* q = ggml_permute(ctx, ggml_cont_3d(ctx, qcur, d_head, n_head, n_tok), 0, 2, 1, 3);
-    ggml_tensor* k = ggml_permute(ctx, ggml_cont_3d(ctx, kcur, d_head, n_head, n_tok), 0, 2, 1, 3);
+    ggml_tensor* q = ggml_permute(ctx, as_contig_3d(ctx, qcur, d_head, n_head, n_tok), 0, 2, 1, 3);
+    ggml_tensor* k = ggml_permute(ctx, as_contig_3d(ctx, kcur, d_head, n_head, n_tok), 0, 2, 1, 3);
     ggml_tensor* kq = ggml_mul_mat(ctx, k, q);
     kq = ggml_scale(ctx, kq, 1.0f / std::sqrt((float)d_head));
     ggml_tensor* kq_soft = causal_soft_max(ctx, tr, kq, 0);
     ggml_tensor* v_trans = ggml_cont_3d(
-        ctx, ggml_permute(ctx, ggml_cont_3d(ctx, vcur, d_head, n_head, n_tok), 1, 2, 0, 3), n_tok,
+        ctx, ggml_permute(ctx, as_contig_3d(ctx, vcur, d_head, n_head, n_tok), 1, 2, 0, 3), n_tok,
         d_head, n_head);
     ggml_tensor* kqv = ggml_mul_mat(ctx, v_trans, kq_soft);
     ggml_tensor* merged = ggml_permute(ctx, kqv, 0, 2, 1, 3);
-    ggml_tensor* out = ggml_cont_2d(ctx, merged, n_embd, n_tok);
+    ggml_tensor* out = as_contig_2d(ctx, merged, n_embd, n_tok);
     return linear(ctx, layer.self_o, out);
 }
 
@@ -1117,7 +1117,7 @@ self_attention_cached(
     ggml_set_name(v_copy, "magpietts_decoder_kv_copy_v");
     ggml_build_forward_expand(gf, v_copy);
 
-    ggml_tensor* q = ggml_permute(ctx, ggml_cont_3d(ctx, qcur, d_head, n_head, n_tok), 0, 2, 1, 3);
+    ggml_tensor* q = ggml_permute(ctx, as_contig_3d(ctx, qcur, d_head, n_head, n_tok), 0, 2, 1, 3);
     ggml_tensor* k = ggml_permute(
         ctx,
         ggml_reshape_3d(
@@ -1139,7 +1139,7 @@ self_attention_cached(
         n_total, d_head, n_head);
     ggml_tensor* kqv = ggml_mul_mat(ctx, v_trans, kq_soft);
     ggml_tensor* merged = ggml_permute(ctx, kqv, 0, 2, 1, 3);
-    ggml_tensor* out = ggml_cont_2d(ctx, merged, n_embd, n_tok);
+    ggml_tensor* out = as_contig_2d(ctx, merged, n_embd, n_tok);
     return linear(ctx, layer.self_o, out);
 }
 
@@ -1159,8 +1159,8 @@ cross_attention(
     ggml_tensor* vcur = ggml_view_2d(
         ctx, kv, d_head * n_head, n_kv, kv->nb[1], (size_t)ggml_element_size(kv) * d_head * n_head);
 
-    ggml_tensor* qh = ggml_permute(ctx, ggml_cont_3d(ctx, q, d_head, n_head, n_q), 0, 2, 1, 3);
-    ggml_tensor* kh = ggml_permute(ctx, ggml_cont_3d(ctx, kcur, d_head, n_head, n_kv), 0, 2, 1, 3);
+    ggml_tensor* qh = ggml_permute(ctx, as_contig_3d(ctx, q, d_head, n_head, n_q), 0, 2, 1, 3);
+    ggml_tensor* kh = ggml_permute(ctx, as_contig_3d(ctx, kcur, d_head, n_head, n_kv), 0, 2, 1, 3);
     ggml_tensor* kq = ggml_mul_mat(ctx, kh, qh);
     kq = ggml_scale(ctx, kq, 1.0f / std::sqrt((float)d_head));
     ggml_tensor* kq_soft = ggml_soft_max(ctx, kq);
@@ -1176,11 +1176,11 @@ cross_attention(
         *last_attn = ggml_cont_2d(ctx, last, n_kv, n_head);
     }
     ggml_tensor* v_trans = ggml_cont_3d(
-        ctx, ggml_permute(ctx, ggml_cont_3d(ctx, vcur, d_head, n_head, n_kv), 1, 2, 0, 3), n_kv,
+        ctx, ggml_permute(ctx, as_contig_3d(ctx, vcur, d_head, n_head, n_kv), 1, 2, 0, 3), n_kv,
         d_head, n_head);
     ggml_tensor* kqv = ggml_mul_mat(ctx, v_trans, kq_soft);
     ggml_tensor* merged = ggml_permute(ctx, kqv, 0, 2, 1, 3);
-    ggml_tensor* out = ggml_cont_2d(ctx, merged, d_head * n_head, n_q);
+    ggml_tensor* out = as_contig_2d(ctx, merged, d_head * n_head, n_q);
     return linear(ctx, layer.cross_o, out);
 }
 
@@ -1199,7 +1199,7 @@ cross_attention_cached(
     const size_t layer_offset =
         (size_t)layer_index * n_kv * cross_dim * ggml_element_size(cross_kv.memory_k);
 
-    ggml_tensor* qh = ggml_permute(ctx, ggml_cont_3d(ctx, q, d_head, n_head, n_q), 0, 2, 1, 3);
+    ggml_tensor* qh = ggml_permute(ctx, as_contig_3d(ctx, q, d_head, n_head, n_q), 0, 2, 1, 3);
     ggml_tensor* kh = ggml_permute(
         ctx,
         ggml_reshape_3d(
@@ -1236,7 +1236,7 @@ cross_attention_cached(
         n_kv, d_head, n_head);
     ggml_tensor* kqv = ggml_mul_mat(ctx, v_trans, kq_soft);
     ggml_tensor* merged = ggml_permute(ctx, kqv, 0, 2, 1, 3);
-    ggml_tensor* out = ggml_cont_2d(ctx, merged, cross_dim, n_q);
+    ggml_tensor* out = as_contig_2d(ctx, merged, cross_dim, n_q);
     return linear(ctx, layer.cross_o, out);
 }
 

--- a/tests/cpp/tts/CMakeLists.txt
+++ b/tests/cpp/tts/CMakeLists.txt
@@ -12,6 +12,11 @@ add_executable(test_magpietts_frame_stacking test_magpietts_frame_stacking.cpp)
 target_link_libraries(test_magpietts_frame_stacking PRIVATE nemo_speech_tts_magpietts)
 add_test(NAME magpietts_frame_stacking COMMAND test_magpietts_frame_stacking)
 
+# Graph-shape test for the as_contig/as_f32_contig helpers: CPU only, no model.
+add_executable(test_magpietts_contiguity_helpers test_magpietts_contiguity_helpers.cpp)
+target_link_libraries(test_magpietts_contiguity_helpers PRIVATE nemo_speech_tts_magpietts)
+add_test(NAME magpietts_contiguity_helpers COMMAND test_magpietts_contiguity_helpers)
+
 if(GGML_CUDA AND NEMO_SPEECH_GGML_PATCHED)
     add_executable(test_magpietts_cached_attention test_magpietts_cached_attention.cpp)
     target_link_libraries(test_magpietts_cached_attention PRIVATE nemo_speech_tts_magpietts)

--- a/tests/cpp/tts/test_magpietts_contiguity_helpers.cpp
+++ b/tests/cpp/tts/test_magpietts_contiguity_helpers.cpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Covers the as_contig/as_f32_contig helpers in src/tts/magpietts/graph.h.
+//
+// The helpers replace ggml_cont/ggml_cont_2d/ggml_cont_3d/ggml_cast at sites
+// where the tensor usually already satisfies what is being asked for. They have
+// to be two things at once, and the two pull in opposite directions:
+//
+//   1. an optimization -- when the input already qualifies, nothing that touches
+//      memory is emitted, because ggml_cont of an already-contiguous tensor is a
+//      full device-to-device copy that computes nothing;
+//   2. never a change in behaviour -- when the input does NOT qualify, the
+//      result must be bit-identical to what the ggml builtin would produce.
+//
+// Checking only (1) would pass a helper that skipped a copy it actually needed,
+// which is the dangerous direction. Checking only (2) would pass a helper that
+// just called ggml_cont every time, which is the thing being removed. So every
+// case below asserts both, against the builtin it replaces: the bytes, and the
+// number of nodes that materialise memory.
+//
+// Raw node count is the wrong measure here. The helpers fall back to
+// ggml_reshape_*, which is still a node but a pure view -- ggml computes nothing
+// for it. What the optimization removes is CONT/CPY/DUP, so those are what get
+// counted. That also makes the F32 cases honest: as_f32_contig drops a redundant
+// CPY even when the input is permuted and a real CONT is still required, so it
+// saves work in both the qualifying and the non-qualifying case, just different
+// amounts.
+//
+// The non-contiguous inputs are built with ggml_permute, which is how they
+// arise at the attention sites these helpers are applied to.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "ggml-cpu.h"
+#include "ggml.h"
+#include "tts/magpietts/graph.h"
+
+namespace {
+
+using nemo_speech::tts::as_contig;
+using nemo_speech::tts::as_contig_2d;
+using nemo_speech::tts::as_contig_3d;
+using nemo_speech::tts::as_f32_contig;
+
+constexpr int64_t kD = 16;  // d_head
+constexpr int64_t kH = 4;   // n_head
+constexpr int64_t kT = 6;   // tokens
+
+using Build = ggml_tensor* (*)(ggml_context*, ggml_tensor*);
+
+ggml_tensor*
+identity(ggml_context*, ggml_tensor* x) {
+    return x;
+}
+
+// Contiguous in memory, but not in ggml's index order, so ggml_is_contiguous is
+// false and a real copy is required.
+ggml_tensor*
+permuted(ggml_context* ctx, ggml_tensor* x) {
+    return ggml_permute(ctx, ggml_reshape_3d(ctx, x, kD, kH, kT), 0, 2, 1, 3);
+}
+
+ggml_tensor*
+bi_cont(ggml_context* ctx, ggml_tensor* t) {
+    return ggml_cont(ctx, t);
+}
+ggml_tensor*
+he_cont(ggml_context* ctx, ggml_tensor* t) {
+    return as_contig(ctx, t);
+}
+ggml_tensor*
+bi_cont2(ggml_context* ctx, ggml_tensor* t) {
+    return ggml_cont_2d(ctx, t, kD * kH, kT);
+}
+ggml_tensor*
+he_cont2(ggml_context* ctx, ggml_tensor* t) {
+    return as_contig_2d(ctx, t, kD * kH, kT);
+}
+ggml_tensor*
+bi_cont3(ggml_context* ctx, ggml_tensor* t) {
+    return ggml_cont_3d(ctx, t, kD, kH, kT);
+}
+ggml_tensor*
+he_cont3(ggml_context* ctx, ggml_tensor* t) {
+    return as_contig_3d(ctx, t, kD, kH, kT);
+}
+// F16 inputs, which is what makes the cast in as_f32_contig a real one rather
+// than a no-op. The cast to F16 is itself a materialising node, so it is counted
+// in both arms and the expected totals below include it.
+ggml_tensor*
+as_f16(ggml_context* ctx, ggml_tensor* x) {
+    return ggml_cast(ctx, x, GGML_TYPE_F16);
+}
+ggml_tensor*
+as_f16_permuted(ggml_context* ctx, ggml_tensor* x) {
+    return ggml_permute(ctx, ggml_reshape_3d(ctx, as_f16(ctx, x), kD, kH, kT), 0, 2, 1, 3);
+}
+
+ggml_tensor*
+bi_f32(ggml_context* ctx, ggml_tensor* t) {
+    return ggml_cont(ctx, ggml_cast(ctx, t, GGML_TYPE_F32));
+}
+ggml_tensor*
+he_f32(ggml_context* ctx, ggml_tensor* t) {
+    return as_f32_contig(ctx, t);
+}
+
+struct Case {
+    const char* name;
+    Build prepare;
+    Build builtin;
+    Build helper;
+    int want_materializing;  // nodes the helper may spend on copies
+};
+
+// CONT, CPY and DUP are the ops that actually move bytes; RESHAPE, VIEW,
+// PERMUTE and TRANSPOSE are views ggml computes nothing for.
+bool
+materializes(ggml_op op) {
+    return op == GGML_OP_CONT || op == GGML_OP_CPY || op == GGML_OP_DUP;
+}
+
+bool
+run_arm(
+    Build prepare, Build build, const std::vector<float>& in, std::vector<uint8_t>& out_bytes,
+    int& out_nodes) {
+    ggml_init_params p = {
+        /*.mem_size   =*/64u * 1024 * 1024,
+        /*.mem_buffer =*/nullptr,
+        /*.no_alloc   =*/false,
+    };
+    ggml_context* ctx = ggml_init(p);
+    if (!ctx) {
+        return false;
+    }
+
+    ggml_tensor* x = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, kD * kH, kT);
+    std::memcpy(x->data, in.data(), in.size() * sizeof(float));
+
+    ggml_tensor* out = build(ctx, prepare(ctx, x));
+
+    ggml_cgraph* gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, out);
+    out_nodes = 0;
+    for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
+        if (materializes(ggml_graph_node(gf, i)->op)) {
+            ++out_nodes;
+        }
+    }
+    ggml_graph_compute_with_ctx(ctx, gf, 1);
+
+    out_bytes.assign((const uint8_t*)out->data, (const uint8_t*)out->data + ggml_nbytes(out));
+    ggml_free(ctx);
+    return true;
+}
+
+}  // namespace
+
+int
+main() {
+    std::vector<float> in((size_t)kD * kH * kT);
+    for (size_t i = 0; i < in.size(); ++i) {
+        in[i] = (float)i * 0.125f - 3.0f;
+    }
+
+    const Case cases[] = {
+        // Already contiguous, already F32: nothing should touch memory at all.
+        {"as_contig / contiguous", identity, bi_cont, he_cont, 0},
+        {"as_contig_2d / contiguous", identity, bi_cont2, he_cont2, 0},
+        {"as_contig_3d / contiguous", identity, bi_cont3, he_cont3, 0},
+        {"as_f32_contig / F32", identity, bi_f32, he_f32, 0},
+        // Permuted: exactly one real copy, and bytes equal to ggml's.
+        {"as_contig / permuted", permuted, bi_cont, he_cont, 1},
+        {"as_contig_3d / permuted", permuted, bi_cont3, he_cont3, 1},
+        {"as_f32_contig / permuted", permuted, bi_f32, he_f32, 1},
+        // F16 in: the cast is required, so the helper must still emit it. Counts
+        // include the one materialising node the F16 input itself costs.
+        {"as_f32_contig / F16", as_f16, bi_f32, he_f32, 2},
+        {"as_f32_contig / F16 permuted", as_f16_permuted, bi_f32, he_f32, 2},
+    };
+
+    int failures = 0;
+    for (const Case& c : cases) {
+        std::vector<uint8_t> want, got;
+        int want_nodes = 0, got_nodes = 0;
+        if (!run_arm(c.prepare, c.builtin, in, want, want_nodes) ||
+            !run_arm(c.prepare, c.helper, in, got, got_nodes)) {
+            std::fprintf(stderr, "FAIL %-28s could not build the graph\n", c.name);
+            ++failures;
+            continue;
+        }
+
+        if (want.size() != got.size() || std::memcmp(want.data(), got.data(), want.size()) != 0) {
+            std::fprintf(
+                stderr, "FAIL %-28s output differs from the ggml builtin (%zu vs %zu bytes)\n",
+                c.name, got.size(), want.size());
+            ++failures;
+        } else if (got_nodes != c.want_materializing) {
+            std::fprintf(
+                stderr,
+                "FAIL %-28s materialises %d node(s), expected %d (the builtin it replaces "
+                "materialises %d)\n",
+                c.name, got_nodes, c.want_materializing, want_nodes);
+            ++failures;
+        } else if (got_nodes > want_nodes) {
+            std::fprintf(
+                stderr, "FAIL %-28s materialises %d node(s), more than the builtin's %d\n", c.name,
+                got_nodes, want_nodes);
+            ++failures;
+        } else {
+            std::fprintf(
+                stderr, "ok   %-28s bytes match, %d copy node(s) against the builtin's %d\n",
+                c.name, got_nodes, want_nodes);
+        }
+    }
+
+    std::fprintf(
+        stderr, "%s: %d of %d cases failed\n", failures ? "FAILED" : "PASSED", failures,
+        (int)(sizeof(cases) / sizeof(cases[0])));
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/cpp/tts/test_magpietts_contiguity_helpers.cpp
+++ b/tests/cpp/tts/test_magpietts_contiguity_helpers.cpp
@@ -175,6 +175,7 @@ main() {
         {"as_f32_contig / F32", identity, bi_f32, he_f32, 0},
         // Permuted: exactly one real copy, and bytes equal to ggml's.
         {"as_contig / permuted", permuted, bi_cont, he_cont, 1},
+        {"as_contig_2d / permuted", permuted, bi_cont2, he_cont2, 1},
         {"as_contig_3d / permuted", permuted, bi_cont3, he_cont3, 1},
         {"as_f32_contig / permuted", permuted, bi_f32, he_f32, 1},
         // F16 in: the cast is required, so the helper must still emit it. Counts


### PR DESCRIPTION
`ggml_cont` on an already-contiguous tensor is a full device-to-device copy that
computes nothing, and `ggml_cast` to the type a tensor already has is the same
copy. Neither elides inside ggml, and the MagpieTTS decode graph asks for both
per step, per layer:

- a head-merge permute that is the identity at `n_head == 1`, so `ggml_cont_2d`
  of it copies a tensor onto itself;
- `ggml_cont_3d` of `qkv` views that the projection already left contiguous;
- sixteen defensive `ggml_cont(ggml_cast(x, F32))` sites where `x` was F32
  already.

They are easy to miss because they are invisible in a kernel profile:
`nsys stats --report cuda_gpu_kern_sum` does not report `cudaMemcpyAsync`, so
none of this shows up in a kernel summary at all.

## The change

Adds four small helpers to `src/tts/magpietts/graph.h` — `as_contig`,
`as_contig_2d`, `as_contig_3d` and `as_f32_contig` — which reshape when the
tensor already qualifies and copy only when it does not. A reshape of a
contiguous tensor is the identical view for free.

Applied at 12 cast sites in `decoder.cpp`, 4 in `lt.cpp`, and 12 `cont_Nd`
sites in `model.cpp` (self-attention, cached self-attention, cross-attention,
cached cross-attention).

`as_f32_contig` also removes the redundant `cont` after a *real* cast:
`ggml_cast` allocates a fresh contiguous tensor, so the `cont` that followed it
was always a no-op copy.

## Measured

GB300, v2602 f16 checkpoint, `--top-k 1` so the code sequence and audio
duration are held fixed and RTF is directly comparable between arms. Median of
5 runs per case, GPU idle-gated. Three cases: one line, a five-sentence
paragraph, a twenty-sentence script.

| case | e2e RTF | decoder ITL |
|---|---|---|
| line | 0.0431 → **0.0416** | 1.78 → 1.71 ms |
| paragraph | 0.0396 → **0.0385** | 1.72 → 1.67 ms |
| script | 0.0397 → **0.0386** | 1.71 → 1.67 ms |

About 2.8%. Run-to-run spread on this harness is ±0.0002 RTF, so the effect is
five to seven times the noise band, and all six measurements (three cases ×
greedy and sampled) move the same direction by the same margin. The sampled
path goes 0.0410 → 0.0399 on the script.

## Correctness

**Output is byte-identical**, which it must be: the kernel launch count does not
change, and the only thing removed is copies that were writing a tensor's
existing contents back over themselves.

Verified rather than asserted — under `--top-k 1` this build is byte
reproducible (confirmed by running the base twice), so the decoded WAVs can be
compared directly. sha256 of the output on all three cases is unchanged:

```
line       5e54074c96b25108   120876 bytes
paragraph  854310de09b63ac4  1122348 bytes
script     0d286892cce07a32  4411436 bytes
```

## Tests

`tests/cpp/tts/test_magpietts_contiguity_helpers.cpp`, registered as
`magpietts_contiguity_helpers`. Nine cases, each asserting **both** halves of
what the helpers have to be, against the ggml builtin they replace:

- the **bytes** are identical — otherwise a helper that just called `ggml_cont`
  every time would pass, which is the thing being removed;
- the number of nodes that **materialise memory** is what it should be —
  otherwise a helper that skipped a copy it actually needed would pass, which is
  the dangerous direction.

Raw node count turned out to be the wrong measure, and writing the test is what
found that: the helpers fall back to `ggml_reshape_*`, which is still a graph
node but a pure view ggml computes nothing for. So the test counts
`CONT`/`CPY`/`DUP`.

```
ok   as_contig / contiguous       bytes match, 0 copy node(s) against the builtin's 1
ok   as_contig_2d / contiguous    bytes match, 0 copy node(s) against the builtin's 1
ok   as_contig_3d / contiguous    bytes match, 0 copy node(s) against the builtin's 1
ok   as_f32_contig / F32          bytes match, 0 copy node(s) against the builtin's 2
ok   as_contig / permuted         bytes match, 1 copy node(s) against the builtin's 1
ok   as_contig_3d / permuted      bytes match, 1 copy node(s) against the builtin's 1
ok   as_f32_contig / permuted     bytes match, 1 copy node(s) against the builtin's 2
ok   as_f32_contig / F16          bytes match, 2 copy node(s) against the builtin's 3
ok   as_f32_contig / F16 permuted bytes match, 2 copy node(s) against the builtin's 3
PASSED: 0 of 9 cases failed
```

Checked against three mutations of `graph.h`, so the cases are known to be able
to fail:

| mutation | caught by |
|---|---|
| always copy (the optimization undone) | 2 failures on node count |
| never copy (a required copy skipped) | 2 failures on bytes |
| skip a genuine F16→F32 cast | 2 failures on bytes |

The third initially passed, because every input was F32 and the cast branch was
never a real cast. The two F16 cases exist for that mutant — without them the
most consequential of the three goes unnoticed.

`ctest` is 9/9 on this branch.

> One note for reviewers: the new test lives in `tests/cpp/tts`, which has a
> pre-existing build failure under `NEMO_SPEECH_BUILD_ASR=OFF` —
> `test_magpietts_asr` includes `recognizer.h`, which is not on the include path
> in that configuration. The new test builds and runs regardless, but
> `cmake --build` on the directory exits non-zero until the CMake guard bundled
> with #28 lands.

## Scope

The two `cont(cast)` sites in `magpietts/encoder.cpp` are deliberately left
alone: the text encoder runs once per chunk rather than once per step, so they
are off the measured path and changing them would not be covered by the numbers
above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary data conversions and memory copies during speech synthesis.
  * Improved efficiency across standard, cached, and attention-based processing paths.
  * Preserved existing outputs, sampling behavior, and generated results while streamlining tensor processing.

* **Quality Improvements**
  * Added validation across different tensor formats and layouts to support reliable speech generation.
  * Improved consistency when processing contiguous and non-contiguous data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->