### PR TITLE
ggml: fix the SVE dot-product tail, and coalesce 1D im2col

### DIFF
--- a/ggml-patches/0022-sve-vec-dot-f32-tail.patch
+++ b/ggml-patches/0022-sve-vec-dot-f32-tail.patch
@@ -1,0 +1,148 @@
+diff --git a/src/ggml-cpu/vec.cpp b/src/ggml-cpu/vec.cpp
+index d0e40013..72c0cde0 100644
+--- a/src/ggml-cpu/vec.cpp
++++ b/src/ggml-cpu/vec.cpp
+@@ -80,7 +80,7 @@ void ggml_vec_dot_f32(int n, float * GGML_RESTRICT s, size_t bs, const float * G
+             svbool_t pg = svwhilelt_b32(np2, n);
+             ax1 = svld1_f32(pg, x + np2);
+             ay1 = svld1_f32(pg, y + np2);
+-            sum1 = svmad_f32_m(pg, ax1, ay1, sum1);
++            sum1 = svmla_f32_m(pg, sum1, ax1, ay1);
+         }
+         // reduce sum1,sum2 to sum1
+         GGML_F32_VEC_REDUCE(sumf, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 7c28e344..b1828604 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -291,6 +291,15 @@ if (NOT GGML_BACKEND_DL)
+     add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
+     set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
+ 
++    #
++    # test-vec-dot-f32
++
++    set(TEST_TARGET test-vec-dot-f32)
++    add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
++    target_link_libraries(${TEST_TARGET} PRIVATE ggml)
++    add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
++    set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
++
+     #
+     # test-conv1d
+ 
+diff --git a/tests/test-vec-dot-f32.cpp b/tests/test-vec-dot-f32.cpp
+new file mode 100644
+index 00000000..5765ab6e
+--- /dev/null
++++ b/tests/test-vec-dot-f32.cpp
+@@ -0,0 +1,109 @@
++// Exactness of the F32 dot product across SIMD tail boundaries.
++//
++// ggml_vec_dot_f32 is the CPU backend's reference implementation, which makes it
++// invisible to test-backend-ops: that harness checks every other backend against
++// the CPU, so a bug in the CPU path is the yardstick rather than the thing being
++// measured. This test checks the CPU against arithmetic instead.
++//
++// The interesting lengths are the ones a vectorised loop cannot cover with whole
++// vectors. Implementations handle the remainder with a predicated or scalar tail,
++// and a tail that merges into the wrong operand can discard lanes of the
++// accumulator -- silently, and only for lengths that are not a multiple of the
++// vector width.
++//
++// Both patterns below are exactly representable in binary32 at these sizes, so
++// the comparison is exact equality and not a tolerance.
++
++#include "ggml.h"
++#include "ggml-cpu.h"
++
++#include <cstdio>
++#include <cstdlib>
++#include <cstring>
++#include <vector>
++
++static float dot_through_ggml(const std::vector<float> & a, const std::vector<float> & b) {
++    const int64_t n = (int64_t) a.size();
++
++    struct ggml_init_params params = {
++        /*.mem_size   =*/ ggml_tensor_overhead() * 8 + ggml_graph_overhead() +
++                          2 * (size_t) n * sizeof(float) + (size_t) 1024 * 1024,
++        /*.mem_buffer =*/ NULL,
++        /*.no_alloc   =*/ false,
++    };
++    struct ggml_context * ctx = ggml_init(params);
++
++    struct ggml_tensor * ta = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n, 1);
++    struct ggml_tensor * tb = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n, 1);
++    memcpy(ta->data, a.data(), (size_t) n * sizeof(float));
++    memcpy(tb->data, b.data(), (size_t) n * sizeof(float));
++
++    struct ggml_tensor  * out = ggml_mul_mat(ctx, ta, tb);
++    struct ggml_cgraph  * gf  = ggml_new_graph(ctx);
++    ggml_build_forward_expand(gf, out);
++    ggml_graph_compute_with_ctx(ctx, gf, 1);
++
++    const float got = ((float *) out->data)[0];
++    ggml_free(ctx);
++    return got;
++}
++
++int main(void) {
++    int failures = 0;
++    int checked  = 0;
++
++    // Lengths that straddle every plausible vector width and unroll step: 1..300
++    // covers 128-, 256-, 512- and 1024-bit vectors with every possible remainder,
++    // and the larger sizes re-check once the unrolled body dominates the tail.
++    std::vector<int64_t> lengths;
++    for (int64_t n = 1; n <= 300; ++n) {
++        lengths.push_back(n);
++    }
++    for (int64_t n : {511, 512, 513, 1023, 1024, 1025, 4095, 4096, 4097}) {
++        lengths.push_back(n);
++    }
++
++    for (int64_t n : lengths) {
++        // Pattern 1: ones against ones. The result is the length itself, so a
++        // dropped lane shows up as a shortfall of exactly the lanes lost.
++        {
++            std::vector<float> a((size_t) n, 1.0f), b((size_t) n, 1.0f);
++            const float want = (float) n;
++            const float got  = dot_through_ggml(a, b);
++            ++checked;
++            if (got != want) {
++                if (failures < 12) {
++                    printf("  n=%-5lld ones      got %12.1f  want %12.1f  (%+.1f%%)\n",
++                           (long long) n, got, want, 100.0 * (got - want) / want);
++                }
++                ++failures;
++            }
++        }
++        // Pattern 2: a ramp against ones. Position-dependent, so a tail that
++        // reads or merges the wrong lane moves the result even when the number
++        // of terms happens to come out right.
++        {
++            std::vector<float> a((size_t) n), b((size_t) n, 1.0f);
++            for (int64_t i = 0; i < n; ++i) {
++                a[(size_t) i] = (float) (i + 1);
++            }
++            const float want = (float) (n * (n + 1) / 2);
++            const float got  = dot_through_ggml(a, b);
++            ++checked;
++            if (got != want) {
++                if (failures < 12) {
++                    printf("  n=%-5lld ramp      got %12.1f  want %12.1f  (%+.1f%%)\n",
++                           (long long) n, got, want, 100.0 * (got - want) / want);
++                }
++                ++failures;
++            }
++        }
++    }
++
++    printf("ggml_vec_dot_f32 exactness (%d cases): %s\n", checked,
++           failures == 0 ? "\033[32mPASSED\033[0m" : "\033[31mFAILED\033[0m");
++    if (failures) {
++        printf("  %d of %d cases wrong\n", failures, checked);
++    }
++    return failures == 0 ? 0 : 1;
++}

--- a/ggml-patches/0023-im2col-1d-coalesced-tiles.patch
+++ b/ggml-patches/0023-im2col-1d-coalesced-tiles.patch
@@ -1,0 +1,128 @@
+diff --git a/src/ggml-cuda/im2col.cu b/src/ggml-cuda/im2col.cu
+--- a/src/ggml-cuda/im2col.cu
++++ b/src/ggml-cuda/im2col.cu
+@@ -43,6 +43,78 @@
+     GGML_UNUSED(KH);
+ }
+ 
++// The generic kernel above indexes threads along IC*KH*KW, which coalesces the store but
++// scatters the load: consecutive threads read addresses IC_IH_IW apart, so a warp issues
++// several short transactions instead of one. For the 1D case that costs most of the
++// achievable bandwidth (measured ~220 GB/s against ~900 GB/s for comparable kernels).
++//
++// Both directions can be coalesced at once by staging a tile through shared memory: load
++// along the input's contiguous axis (OW), store along the destination's (IC*KW). The
++// shared tile is padded to an odd word stride so the transposed access is conflict-free.
++#define IM2COL_1D_TILE_OW 64
++#define IM2COL_1D_TILE_I  32
++
++template <typename T>
++static __global__ void im2col_1d_tiled_kernel(
++        const float * __restrict__ x, T * __restrict__ dst,
++        const int64_t IC_KW, const int64_t IW, const int64_t OW, const int64_t KW,
++        const int64_t IC_IH_IW, const int64_t IH_IW,
++        const int s0, const int p0, const int d0) {
++
++    __shared__ float tile[IM2COL_1D_TILE_I][IM2COL_1D_TILE_OW + 1];
++    // The channel and kernel tap depend only on the row of the tile, so resolve them once
++    // per row rather than once per element: the division is otherwise the dominant cost.
++    __shared__ int64_t s_base[IM2COL_1D_TILE_I];
++    __shared__ int     s_off[IM2COL_1D_TILE_I];
++
++    const int64_t ow0 = (int64_t) blockIdx.x * IM2COL_1D_TILE_OW;
++    const int64_t i0  = (int64_t) blockIdx.y * IM2COL_1D_TILE_I;
++    const int64_t in  = blockIdx.z;
++
++    if (threadIdx.x < IM2COL_1D_TILE_I) {
++        const int64_t i = i0 + threadIdx.x;
++        int64_t base = 0;
++        int off = 0;
++        if (i < IC_KW) {
++            const int64_t iic = i / KW;
++            const int64_t ikw = i - iic * KW;
++            base = iic * IC_IH_IW + in * IH_IW;
++            off  = (int) (ikw * d0 - p0);
++        }
++        s_base[threadIdx.x] = base;
++        s_off[threadIdx.x]  = off;
++    }
++    __syncthreads();
++
++    // load: consecutive threads walk OW, which is contiguous in the source
++    for (int idx = threadIdx.x; idx < IM2COL_1D_TILE_I * IM2COL_1D_TILE_OW; idx += blockDim.x) {
++        const int il = idx / IM2COL_1D_TILE_OW;
++        const int ol = idx - il * IM2COL_1D_TILE_OW;
++        const int64_t i  = i0  + il;
++        const int64_t ow = ow0 + ol;
++        float v = 0.0f;
++        if (i < IC_KW && ow < OW) {
++            const int64_t iiw = ow * s0 + s_off[il];
++            if (iiw >= 0 && iiw < IW) {
++                v = x[s_base[il] + iiw];
++            }
++        }
++        tile[il][ol] = v;
++    }
++    __syncthreads();
++
++    // store: consecutive threads walk IC*KW, which is contiguous in the destination
++    for (int idx = threadIdx.x; idx < IM2COL_1D_TILE_I * IM2COL_1D_TILE_OW; idx += blockDim.x) {
++        const int ol = idx / IM2COL_1D_TILE_I;
++        const int il = idx - ol * IM2COL_1D_TILE_I;
++        const int64_t i  = i0  + il;
++        const int64_t ow = ow0 + ol;
++        if (i < IC_KW && ow < OW) {
++            dst[(in * OW + ow) * IC_KW + i] = tile[il][ol];
++        }
++    }
++}
++
+ // im2col: [N, IC, IH, IW] => [N, OH, OW, IC*KH*KW]
+ template <typename T>
+ static void im2col_cuda(const float * x, T* dst,
+@@ -50,6 +122,18 @@
+     int64_t N, int64_t IC_IH_IW, int64_t IH_IW,
+     int s0,int s1,int p0,int p1,int d0,int d1, cudaStream_t stream) {
+     const int64_t IC_KH_KW = IC * KH * KW;
++
++    // 1D convolutions take the tiled path; everything else keeps the generic kernel.
++    if (KH == 1 && IH == 1 && OH == 1 && N <= 65535) {
++        dim3 blocks(
++            (OW       + IM2COL_1D_TILE_OW - 1) / IM2COL_1D_TILE_OW,
++            (IC_KH_KW + IM2COL_1D_TILE_I  - 1) / IM2COL_1D_TILE_I,
++            N);
++        im2col_1d_tiled_kernel<T><<<blocks, 256, 0, stream>>>(
++            x, dst, IC_KH_KW, IW, OW, KW, IC_IH_IW, IH_IW, s0, p0, d0);
++        return;
++    }
++
+     const int64_t num_blocks = (IC_KH_KW + CUDA_IM2COL_BLOCK_SIZE - 1) / CUDA_IM2COL_BLOCK_SIZE;
+     const int64_t N_OH = N * OH;
+     const int64_t KH_KW = KW*KH;
+diff --git a/tests/test-backend-ops.cpp b/tests/test-backend-ops.cpp
+index f54ab41c..62977e67 100644
+--- a/tests/test-backend-ops.cpp
++++ b/tests/test-backend-ops.cpp
+@@ -7749,6 +7749,22 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
+         }
+     }
+ 
++    // im2col 1D, wide enough that a tiled implementation has to cover a full tile
++    // interior as well as its edges. The cases above are either 1-batch with unit
++    // stride and dilation, or too short (OW=18) to fill a tile at all, so a bug in
++    // the interior of a blocked kernel survives them.
++    //   OW=148, IC*KW=170: partial tile on both axes, batched, non-unit s0/p0/d0
++    test_cases.emplace_back(new test_im2col(
++        GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32, {300, 34, 3, 1}, {5, 34, 8, 1},
++        2, 0, 2, 0, 2, 0, false));
++    test_cases.emplace_back(new test_im2col(
++        GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {300, 34, 3, 1}, {5, 34, 8, 1},
++        2, 0, 2, 0, 2, 0, false));
++    //   OW=255, IC*KW=192: OW one short of a 64-multiple, IC*KW an exact multiple
++    test_cases.emplace_back(new test_im2col(
++        GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32, {257, 64, 2, 1}, {3, 64, 8, 1},
++        1, 0, 0, 0, 1, 0, false));
++
+     // im2col 2D
+     test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32));
+     test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F32));

--- a/ggml-patches/0023-im2col-1d-coalesced-tiles.patch
+++ b/ggml-patches/0023-im2col-1d-coalesced-tiles.patch
@@ -80,13 +80,17 @@ diff --git a/src/ggml-cuda/im2col.cu b/src/ggml-cuda/im2col.cu
  // im2col: [N, IC, IH, IW] => [N, OH, OW, IC*KH*KW]
  template <typename T>
  static void im2col_cuda(const float * x, T* dst,
-@@ -50,6 +122,18 @@
+@@ -50,6 +122,22 @@
      int64_t N, int64_t IC_IH_IW, int64_t IH_IW,
      int s0,int s1,int p0,int p1,int d0,int d1, cudaStream_t stream) {
      const int64_t IC_KH_KW = IC * KH * KW;
 +
 +    // 1D convolutions take the tiled path; everything else keeps the generic kernel.
-+    if (KH == 1 && IH == 1 && OH == 1 && N <= 65535) {
++    // The tiled kernel has no height axis, so a degenerate 2D call must not reach it:
++    // ggml_conv_1d passes s1 = p1 = d1 = 0, but a 2D call can have IH == KH == OH == 1
++    // with a nonzero p1, where the generic kernel emits padded zeroes and this one would
++    // read input samples instead.
++    if (KH == 1 && IH == 1 && OH == 1 && s1 == 0 && p1 == 0 && d1 == 0 && N <= 65535) {
 +        dim3 blocks(
 +            (OW       + IM2COL_1D_TILE_OW - 1) / IM2COL_1D_TILE_OW,
 +            (IC_KH_KW + IM2COL_1D_TILE_I  - 1) / IM2COL_1D_TILE_I,
@@ -103,7 +107,7 @@ diff --git a/tests/test-backend-ops.cpp b/tests/test-backend-ops.cpp
 index f54ab41c..62977e67 100644
 --- a/tests/test-backend-ops.cpp
 +++ b/tests/test-backend-ops.cpp
-@@ -7749,6 +7749,22 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
+@@ -7749,6 +7749,27 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
          }
      }
  
@@ -118,6 +122,11 @@ index f54ab41c..62977e67 100644
 +    test_cases.emplace_back(new test_im2col(
 +        GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {300, 34, 3, 1}, {5, 34, 8, 1},
 +        2, 0, 2, 0, 2, 0, false));
++    // Degenerate 2D: IH == KH == 1 and OH == 1, but p1 != 0, so the generic kernel pads
++    // with zeroes. Guards the tiled dispatch against claiming this as a 1D convolution.
++    test_cases.emplace_back(new test_im2col(
++        GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32, {300, 1, 34, 1}, {5, 1, 34, 8},
++        2, 3, 2, 1, 2, 1, true));
 +    //   OW=255, IC*KW=192: OW one short of a 64-multiple, IC*KW an exact multiple
 +    test_cases.emplace_back(new test_im2col(
 +        GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32, {257, 64, 2, 1}, {3, 64, 8, 1},

--- a/ggml-patches/README.md
+++ b/ggml-patches/README.md
@@ -143,6 +143,31 @@ stock comparison therefore requires both a pristine ggml checkout and
   ReLU epilogues. This preserves the VoiceChat perception stem's native BF16
   behavior without adding standalone conversion kernels.
 
+- **0022-sve-vec-dot-f32-tail.patch** - fixes ggml_vec_dot_f32's predicated SVE
+  tail, which used svmad_f32_m. That intrinsic merges into its first operand,
+  so the inactive lanes of the accumulator took the zeroed lanes of the freshly
+  loaded x vector instead of keeping their running sums. Any dot product longer
+  than one SVE vector whose length is not a multiple of the vector width
+  silently lost work -- on a 128-bit implementation, 25%, 49% or 74% of the
+  result depending on the tail length. This is an upstream ggml bug and should
+  also be sent to ggml. `test-backend-ops -o CONV_TRANSPOSE_1D` already fails
+  on an SVE host because of it, but blames the wrong side: the harness scores
+  every backend against the CPU, so a bug in the CPU presents as the CUDA
+  kernel being wrong. The patch also carries `tests/test-vec-dot-f32.cpp`,
+  which checks the CPU against arithmetic and so names the culprit -- and is
+  the only one of the two that catches it at all in a CPU-only build, where
+  there is no second backend to disagree.
+
+- **0023-im2col-1d-coalesced-tiles.patch** - the generic im2col coalesces its
+  store but scatters its load, leaving warp neighbours far apart in the source
+  row. Staging each output tile through shared memory makes both sides
+  contiguous. Bit-identical output; the kernel goes from 74.3 ms to 61.3 ms
+  over the same 12,052 launches on a five-sentence paragraph. Extends the
+  existing im2col 1D cases in `tests/test-backend-ops.cpp`: those are either
+  too short to fill a tile (OW=18) or unit-stride and single-batch, so three
+  defect classes confined to the interior of a blocked kernel survive all
+  eleven of them.
+
 ## Regenerating after editing ggml
 
 Several patches touch the same ggml files, so regenerating a patch from the


### PR DESCRIPTION
Two independent ggml patches. Both are upstream-ggml issues rather than
NeMo-Speech ones, and both should go to ggml as well; they are carried here
because `ggml-patches/` is how this repo consumes ggml changes.

They are in one PR because they are both single additions to the series with no
other footprint. They are separate commits and can be split if you would rather
take them one at a time.

> **Numbering:** these are `0019` and `0020` because #28 claims `0018`. If #28
> lands after this, or not at all, they will need renumbering — happy to rebase.

---

## `0019-sve-vec-dot-f32-tail` — a correctness fix

`ggml_vec_dot_f32`'s predicated SVE tail used:

```c
sum1 = svmad_f32_m(pg, ax1, ay1, sum1);
```

The `_m` form merges into its **first** operand. Here that is `ax1`, not the
accumulator — and `ax1` comes from a predicated `svld1_f32`, whose inactive
lanes are zero. So the tail step overwrote the inactive lanes of the
accumulator with zero, discarding every partial sum they held.

```c
sum1 = svmla_f32_m(pg, sum1, ax1, ay1);   // same product, merges into sum1
```

The effect is large. Any dot product longer than one SVE vector whose length is
not a multiple of the vector width loses the lanes the tail does not cover. A
standalone reproduction running the same data through both intrinsics on a
128-bit SVE host (4 floats per vector):

| n | `svmad_f32_m` (today) | exact | error |
|---|---|---|---|
| 101 | 67.08 | 260.83 | **−74.3%** |
| 102 | 134.42 | 263.84 | **−49.1%** |
| 103 | 202.01 | 266.85 | **−24.3%** |
| 104 | 269.86 | 269.86 | 0.0% (no tail) |

We found it through NanoCodec, where it moved CPU-decoded audio by 23 dB.

It has **no effect on the CUDA benchmarks** — confirmed by measuring with and
without it on top of the im2col patch below, which reproduced the same RTF to
within the harness's ±0.0002. The CUDA path does not call this function. It
matters for CPU inference on any SVE machine.

### Tests

**ggml already fails on this**, and that is worth stating plainly. On an SVE
host, `test-backend-ops -o CONV_TRANSPOSE_1D` fails today at every case with 7
channels — 7 % 4 ≠ 0 on a 128-bit implementation — with errors up to 72.1
against a 1e-7 threshold:

```
[CONV_TRANSPOSE_1D] ERR = 48.725056877 > 0.000000100   ne_input=[1,7,1,1],ne_kernel=[1,1,7,1],s0=1: FAIL
[CONV_TRANSPOSE_1D] ERR = 72.132731258 > 0.000000100   ne_input=[1,7,1,1],ne_kernel=[1,1,7,1],s0=2: FAIL
[CONV_TRANSPOSE_1D] ERR =  0.075775883 > 0.000000100   ne_input=[2,7,1,1],ne_kernel=[1,1,7,1],s0=1: FAIL
```

What that suite cannot do is say *who* is wrong. It scores every backend against
the CPU, so a fault in the CPU presents as the CUDA kernel being broken — which
is very likely why this survived: the signal pointed away from the bug. With the
patch, CONV_TRANSPOSE_1D goes to OK.

So the patch also adds `tests/test-vec-dot-f32.cpp`, which checks the CPU
against arithmetic rather than against another backend, and therefore names the
culprit. It covers something the existing test structurally cannot, too: in a
**CPU-only build** there is no second backend to disagree, `test-backend-ops`
skips the CPU as its own reference, and the bug is invisible. That is exactly
the configuration where it matters, since the CUDA path never calls this
function.

618 cases — lengths 1 to 300 plus sizes around 512, 1024 and 4096, each with two
patterns whose exact result is known in binary32 (ones against ones, and a ramp
against ones, so a dropped lane and a misread lane look different).

Unpatched, on a 128-bit SVE host, it fails **456 of 618**:

```
  n=5     ones      got          2.0  want          5.0  (-60.0%)
  n=9     ones      got          3.0  want          9.0  (-66.7%)
  n=10    ones      got          6.0  want         10.0  (-40.0%)
  n=11    ones      got          9.0  want         11.0  (-18.2%)
ggml_vec_dot_f32 exactness (618 cases): FAILED
  456 of 618 cases wrong
```

Patched, 618 of 618 pass. Lengths that are exact multiples of the vector width
pass either way, which is the other half of why this survived — it only bites on
a remainder.

---

## `0020-im2col-1d-coalesced-tiles` — a perf patch, bit-identical

The generic im2col kernel coalesces its store but scatters its load:
consecutive threads write neighbouring output elements, which for a 1D
convolution sit far apart in the source row. At NanoCodec's last upsampling
layer that is 65 KB between warp neighbours, and the kernel sustains ~220 GB/s
where sibling kernels on the same device reach ~900.

The patch stages each output tile through shared memory, so both the load and
the store are contiguous.

**This is not only a codec kernel.** On the v2602 MagpieTTS checkpoint the
decoder's convolutional feed-forward blocks issue im2col every layer, every
step — all 12,052 of the launches in a five-sentence paragraph. That is why the
win shows up in decoder inter-token latency rather than in codec throughput.

### Measured

GB300, v2602 f16, `--top-k 1` so the code sequence is held fixed, median of 5
runs per case, GPU idle-gated. Applied on top of #32 (the no-op contiguity elision), which is its baseline
here — these two are independent and can land in either order:

| case | e2e RTF | decoder ITL |
|---|---|---|
| line | 0.0416 → **0.0408** | 1.71 → 1.68 ms |
| paragraph | 0.0385 → **0.0375** | 1.67 → 1.63 ms |
| script | 0.0386 → **0.0374** | 1.67 → 1.61 ms |

By kernel, on the paragraph with `--cuda-graph-trace=node`: im2col goes
**74.3 ms → 61.3 ms, −17.5%**, over an unchanged 12,052 launches.

### Correctness

Output is **bit-identical**, verified by sha256 of the decoded WAV on all three
cases (this build is byte-reproducible under `--top-k 1`).

### Tests

The patch extends the `im2col 1D` cases in `test-backend-ops`. The existing ones
*do* exercise the new kernel — and pass — but thinly: three cases at OW=3000
with unit stride, single batch, and `IC*KW` an exact multiple of the tile
height, plus eight at OW=18, which is too short to fill a tile at all.

Six single-point mutants of the new kernel are caught by that suite. Three
defect classes are not:

| mutant | caught by existing 11 | caught by added 3 |
|---|---|---|
| fault confined to partial-`IC*KW` rows of a *later* OW tile | ✗ 0 | ✓ 2 |
| fault affecting only batch > 0 in a later tile | ✗ 0 | ✓ 3 |
| fault affecting only stride > 1 in a tile interior | ✗ 0 | ✓ 2 |

Each escapes all eleven existing cases entirely. The three added cases combine a
full tile interior with non-unit stride, dilation and padding, batch > 1, and
partial tiles on both axes — which is the shape of defect a blocked kernel
actually has.

The added cases also pass against the **stock generic kernel** with the tiled
dispatch disabled, so they test im2col's semantics rather than this
implementation's, and would be equally valid in ggml without this patch.

All 14 1D cases pass on this branch, on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed ARM SVE F32 dot products for vector lengths containing tail elements.

- **Performance**
  - Improved CUDA 1D convolution preprocessing with coalesced tiled memory access while preserving identical results.

- **Tests**
  - Added coverage for SVE dot products across SIMD-width and tail boundaries.
  - Added CUDA convolution tests for batching, tile boundaries, padding, stride, dilation, and F16 output.
  - Added coverage ensuring degenerate 2D cases continue to use the appropriate processing path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->