### PR TITLE
fix(tts): do not split a sentence at an abbreviation's period

### DIFF
--- a/src/tts/tokenizer/tokenizer_impl.cpp
+++ b/src/tts/tokenizer/tokenizer_impl.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -763,6 +764,51 @@ cjk_terminal_size_at(const std::string& text, size_t position) {
     return 0;
 }
 
+// A period after one of these is an abbreviation, not the end of a sentence.
+// Splitting there puts a chunk boundary -- with its own BOS, attention prior and
+// boundary silence -- inside a sentence, which is audible.
+static bool
+abbreviation_before(const std::string& text, size_t period) {
+    static const std::array<const char*, 26> known = {
+        "mr",  "mrs", "ms",  "dr",  "prof", "sr",     "jr",   "st",  "mt",
+        "rev", "hon", "gen", "col", "capt", "lt",     "sgt",  "gov", "sen",
+        "rep", "vs",  "etc", "eg",  "ie",   "approx", "dept", "est"};
+
+    size_t end = period;  // scan the word ending at the period
+    size_t begin = end;
+    while (begin > 0) {
+        const unsigned char c = (unsigned char)text[begin - 1];
+        if (!std::isalpha(c) && c != '.') {
+            break;
+        }
+        --begin;
+    }
+    if (begin == end) {
+        return false;
+    }
+    std::string word;
+    for (size_t i = begin; i < end; ++i) {
+        const unsigned char c = (unsigned char)text[i];
+        if (c != '.') {
+            word.push_back((char)std::tolower(c));
+        }
+    }
+    if (word.empty()) {
+        return false;
+    }
+    // A single letter ("J. R. R.") or an internally dotted form ("U.S.",
+    // "e.g.") is an initialism, never a terminator.
+    if (word.size() == 1) {
+        return true;
+    }
+    if (text.compare(begin, end - begin, word) != 0 &&
+        std::count(text.begin() + (long)begin, text.begin() + (long)end, '.') > 0) {
+        return true;
+    }
+    return std::find_if(known.begin(), known.end(), [&](const char* k) { return word == k; }) !=
+           known.end();
+}
+
 static std::vector<std::string>
 split_sentences(std::string paragraph) {
     paragraph = replace_all(paragraph, "-", " ");
@@ -776,7 +822,10 @@ split_sentences(std::string paragraph) {
     for (size_t i = 0; i < paragraph.size(); ++i) {
         const char c = paragraph[i];
         const char next = i + 1 < paragraph.size() ? paragraph[i + 1] : '\0';
-        const bool ascii_boundary = (c == '.' || c == '?' || c == '!') && next == ' ';
+        bool ascii_boundary = (c == '.' || c == '?' || c == '!') && next == ' ';
+        if (ascii_boundary && c == '.' && abbreviation_before(paragraph, i)) {
+            ascii_boundary = false;
+        }
         const size_t cjk_terminal_size = cjk_terminal_size_at(paragraph, i);
         if (ascii_boundary || cjk_terminal_size != 0) {
             size_t end = i + (ascii_boundary ? 1 : cjk_terminal_size);

--- a/tests/cpp/tts/CMakeLists.txt
+++ b/tests/cpp/tts/CMakeLists.txt
@@ -77,6 +77,14 @@ if(NEMO_SPEECH_TTS_WITH_ZH)
     endif()
 endif()
 
+add_executable(test_sentence_splitting test_sentence_splitting.cpp)
+target_link_libraries(test_sentence_splitting PRIVATE nemo_speech_tts_tokenizer)
+if(DEFINED ENV{NEMO_SPEECH_TEST_TOKENIZER_DIR_V2602})
+    add_test(
+        NAME sentence_splitting
+        COMMAND test_sentence_splitting $ENV{NEMO_SPEECH_TEST_TOKENIZER_DIR_V2602})
+endif()
+
 add_executable(test_tts_terminal_punctuation test_tts_terminal_punctuation.cpp)
 target_link_libraries(test_tts_terminal_punctuation PRIVATE nemo_speech_tts_tokenizer)
 

--- a/tests/cpp/tts/test_sentence_splitting.cpp
+++ b/tests/cpp/tts/test_sentence_splitting.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Where the tokenizer splits a paragraph into chunks.
+//
+// Each chunk becomes an independent decode: its own BOS, its own attention
+// prior, its own boundary silence. A split inside a sentence is therefore
+// audible, and the naive rule -- period followed by a space -- puts one inside
+// every abbreviation. These cases pin the guard against that.
+//
+// Requires the tokenizer assets; skips (exit 0) without them.
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "tts/tokenizer/tokenizer.h"
+
+namespace {
+
+int failures = 0;
+
+std::vector<std::string>
+chunks_of(const nemo_speech::tts::MagpieNativeTokenizer& tok, const std::string& text) {
+    std::vector<std::string> out;
+    for (const auto& c : tok.tokenize(text, "en-US").chunks) {
+        out.push_back(c.text);
+    }
+    return out;
+}
+
+void
+expect_chunks(
+    const nemo_speech::tts::MagpieNativeTokenizer& tok, const std::string& text, size_t expected,
+    const char* why) {
+    const std::vector<std::string> got = chunks_of(tok, text);
+    if (got.size() == expected) {
+        return;
+    }
+    std::fprintf(
+        stderr, "FAIL: %s\n  text:     %s\n  expected: %zu chunk(s), got %zu\n", why, text.c_str(),
+        expected, got.size());
+    for (const std::string& c : got) {
+        std::fprintf(stderr, "    | %s\n", c.c_str());
+    }
+    ++failures;
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s TOKENIZER_MODEL_DIR\n", argv[0]);
+        return 2;
+    }
+    nemo_speech::tts::MagpieNativeTokenizer tok(argv[1]);
+
+    // Sentence chunking is gated on the *word count of the whole text* --
+    // should_tokenize_by_sentence measures words, not characters, and English
+    // needs 45 of them. Below that the text stays one chunk however it is
+    // punctuated, so every case here is padded past the gate; otherwise the
+    // test passes whether or not the splitter works.
+    // Two filler sentences, 48 words, so every case clears the 45-word gate
+    // with margin and the counts below are about the splitter, not the gate.
+    const std::string filler =
+        "Everyone in the surrounding villages had been waiting for news about the "
+        "harvest for several weeks by then, and the roads were still difficult. "
+        "The old bridge had been closed since the middle of the previous winter, "
+        "which meant the only route left was the long one around the valley. ";
+
+    // A real boundary splits once the gate is cleared.
+    expect_chunks(
+        tok,
+        filler +
+            "The rain continued steadily throughout the entire afternoon. "
+            "Everyone waited inside until the sky finally cleared again.",
+        4, "real sentence boundaries split");
+
+    // Abbreviations do not add a boundary.
+    expect_chunks(
+        tok,
+        filler +
+            "The committee agreed that the U.S. government should be told "
+            "about the decision before any of it becomes public.",
+        3, "U.S. mid-sentence does not split");
+    expect_chunks(
+        tok,
+        filler +
+            "After a long and tedious meeting Dr. Smith agreed to review "
+            "all of the remaining proposals himself before Friday.",
+        3, "Dr. mid-sentence does not split");
+    expect_chunks(
+        tok,
+        filler +
+            "He recommended bringing something warm for the evening, e.g. "
+            "a heavy coat, because the weather here turns very quickly.",
+        3, "e.g. mid-sentence does not split");
+    expect_chunks(
+        tok,
+        filler +
+            "The visitors gathered outside before walking on to St. Mary "
+            "and continuing along the river path together until dusk.",
+        3, "St. mid-sentence does not split");
+
+    // Both behaviours together.
+    expect_chunks(
+        tok,
+        filler +
+            "After a long meeting Dr. Smith agreed to review the proposals. "
+            "Everyone else went home for the evening without waiting.",
+        4, "abbreviation held, real boundary split");
+
+    if (failures == 0) {
+        std::printf("test_sentence_splitting: all checks passed\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
`split_sentences` ends a sentence at any `.`, `?` or `!` followed by a space.
That puts a boundary inside `"Dr. Smith"`, `"the U.S. government"`,
`"e.g. a coat"` and `"St. Mary"`.

This is not cosmetic. Each chunk is an **independent decode** — its own BOS, its
own attention prior, its own boundary silence — so a split in the middle of a
sentence is audible as a pause and a prosody reset where there should be none.

## Measured on this tree

One three-sentence paragraph of 59 words containing `Dr.`, `Mrs.`, `U.S.`,
`e.g.` and `St.`:

```
Dr. Smith and Mrs. Jones travelled to the U.S. capital last week in order to
present their latest findings. The committee then met for several hours to
discuss the funding proposal in detail, e.g. the timeline and the staffing plan
for next year. St. Mary hospital will receive the first allocation of the new
equipment sometime early next spring.
```

| | chunks decoded |
|---|---|
| `main` today | **8** |
| with this patch | **3** |

Three sentences plus five abbreviation periods is exactly the eight.

## The guard

Holds the boundary when the word before the period is:

- a known abbreviation (`mr`, `mrs`, `dr`, `prof`, `st`, `etc`, `eg`, `ie`, …);
- a single letter — `"J. R. R. Tolkien"`;
- internally dotted — `"U.S."`, `"e.g."`.

CJK terminal handling is untouched, and `?`/`!` are unaffected.

## Tests

Adds `tests/cpp/tts/test_sentence_splitting.cpp`, registered as
`sentence_splitting` under the same
`NEMO_SPEECH_TEST_TOKENIZER_DIR_V2602` guard the existing tokenizer tests use.

The test needed two attempts to be worth anything, which is worth recording for
anyone extending it: sentence chunking is gated on the word count of the
**whole** text — `should_tokenize_by_sentence` counts words, not characters, and
English needs 45 — so short cases come back as one chunk whether or not the
splitter works, and pass for the wrong reason. Every case now clears that gate
with margin.

Verified in the failing direction too. With the guard removed, five cases fail,
e.g.:

```
FAIL: abbreviation held, real boundary split
  expected: 4 chunk(s), got 5
    | ...
    | After a long meeting Dr.
    | Smith agreed to review the proposals.
    | Everyone else went home for the evening without waiting.
```

## Where this belongs eventually

Sparrowhawk already exposes `Normalizer::SentenceSplitter()`, backed by a
`SentenceBoundary` class whose stated job is abbreviations that end in periods —
that is the correct general answer. It needs `NEMO_SPEECH_WITH_NORM` (off by
default, pulls in OpenFST and protobuf) plus a boundary regexp and exception
list that are not shipped here, and the benchmark path deliberately runs with
normalization off, so it cannot be a hard dependency today. This guard is the
part that protects prosody now; it can be retired when the normalizer path
becomes the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sentence splitting to avoid incorrectly breaking sentences after common abbreviations, initials, and dotted initialisms.
  - Preserved sentence boundary handling for regular English and CJK punctuation.

- **Tests**
  - Added coverage for genuine sentence boundaries and abbreviation-heavy text, including examples such as “U.S.”, “Dr.”, “e.g.”, and “St.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->