### PR TITLE
perf(codec): keep NanoCodec stream state on device

### DIFF
--- a/scripts/tts/bench_magpietts.py
+++ b/scripts/tts/bench_magpietts.py
@@ -66,12 +66,17 @@ def text_for(n):
 
 
 def gpu_util():
+    # The busiest GPU on the box, not the first row. synthesize does not take a CUDA
+    # index -- it initializes the first available device -- and CUDA_VISIBLE_DEVICES can
+    # map that onto any physical GPU, so reading row 0 can approve an idle card while
+    # the one running the synthesis is saturated.
     out = subprocess.run(
         ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"],
         capture_output=True,
         text=True,
     ).stdout
-    return int(re.sub(r"\D", "", out.splitlines()[0] or "100"))
+    vals = [int(re.sub(r"\D", "", line)) for line in out.splitlines() if re.search(r"\d", line)]
+    return max(vals) if vals else 100
 
 
 def wait_idle(threshold=3, consecutive=4, timeout=600):
@@ -108,7 +113,10 @@ def run_once(a, text, out_path):
     ]
     if a.greedy:
         cmd += ["--top-k", "1"]
-    cmd += a.extra
+    # --extra goes first: command_synthesize applies options in argument order, so
+    # anything the benchmark owns has to be appended after it. A duplicated --output
+    # would otherwise make the run hash a different file than the one it wrote.
+    cmd = cmd[:3] + a.extra + cmd[3:]
     p = subprocess.run(cmd, capture_output=True, text=True)
     if p.returncode != 0:
         sys.exit(f"synthesize failed:\n{p.stderr[-2000:]}")
@@ -139,7 +147,7 @@ def main():
     ap.add_argument("--device", default="cuda")
     ap.add_argument("--voice", default="John")
     ap.add_argument("--seed", type=int, default=7)
-    ap.add_argument("--reps", type=int, default=5)
+    ap.add_argument("--reps", type=int, default=5, help="runs per case; must be at least 1")
     ap.add_argument("--out", default="/tmp/bench_magpietts.wav")
     ap.add_argument("--label", default="run")
     ap.add_argument("--json", help="write raw per-run metrics here")
@@ -165,6 +173,10 @@ def main():
         help="everything after this is passed to synthesize",
     )
     a = ap.parse_args()
+    # Zero or fewer leaves every metric list empty, and the median map then has no
+    # e2e_rtf for the report to read.
+    if a.reps < 1:
+        ap.error("--reps must be at least 1")
 
     if not a.allow_busy_gpu and a.device.startswith("cuda") and not wait_idle():
         sys.exit("GPU never went idle; refusing to benchmark under load")

--- a/scripts/tts/bench_magpietts.py
+++ b/scripts/tts/bench_magpietts.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Measure MagpieTTS synthesis speed, and check that it is reproducible.
+
+Self-contained: the text is inlined below, so a run is reproducible from this
+file plus a binary and the model files.
+
+    scripts/tts/bench_magpietts.py \
+        --bin build/cuda-speech/bin/nemo-speech \
+        --magpie MAGPIE.gguf --codec CODEC.gguf --tokenizer TOKENIZER_DIR
+
+Three cases of increasing length -- one line, a five-sentence paragraph, a
+twenty-sentence script -- because RTF does not scale flatly with input length
+and a single short utterance hides both long-form and codec behaviour.
+
+Two things about the methodology are worth knowing before trusting a number.
+
+**Use --greedy for any A/B comparison.** Sampled decoding picks a different code
+sequence when anything perturbs the arithmetic, which changes the audio
+*duration*, which moves RTF on its own. Greedy holds the sequence fixed, so RTF
+is comparable between arms and the output is byte-reproducible.
+
+**The GPU must be idle.** A background job on the same device moves these
+numbers by 2-4x. This script refuses to start until nvidia-smi reports <= 3%
+for four consecutive samples, and re-checks between cases.
+
+`--check` skips timing and instead runs each case N times, reporting the sha256
+of the decoded WAV. Under --greedy every run must produce the same hash; if they
+differ, the pipeline is not reproducible and no benchmark taken against it means
+anything. That is not hypothetical -- see the half_snake fusion aliasing guard.
+"""
+import argparse
+import hashlib
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+
+# The sentence pool. Do not reword or reorder: the sentences and their order
+# determine audio duration, and comparability across runs depends on them.
+SENTENCES = [
+    "Magpie is a text to speech model.",
+    "It generates audio codes autoregressively and then decodes them with a neural codec.",
+    "This paragraph is long enough that the server treats it as long form input.",
+    "We want to know how the wall clock time scales with the number of sentences.",
+    "Here is more filler text to push us well past the language threshold.",
+]
+CASES = [("line", 1), ("paragraph", 5), ("script", 20)]
+
+METRICS = (
+    "e2e_rtf",
+    "decoder_itl_avg_ms",
+    "codec_rtfx",
+    "codec_ttfa_ms",
+    "e2e_ttfa_ms",
+    "e2e_audio_s",
+)
+
+
+def text_for(n):
+    return " ".join((SENTENCES * 8)[:n])
+
+
+def gpu_util():
+    out = subprocess.run(
+        ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"],
+        capture_output=True,
+        text=True,
+    ).stdout
+    return int(re.sub(r"\D", "", out.splitlines()[0] or "100"))
+
+
+def wait_idle(threshold=3, consecutive=4, timeout=600):
+    ok, deadline = 0, time.time() + timeout
+    while time.time() < deadline:
+        ok = ok + 1 if gpu_util() <= threshold else 0
+        if ok >= consecutive:
+            return True
+        time.sleep(2)
+    return False
+
+
+def run_once(a, text, out_path):
+    cmd = [
+        a.bin, "synthesize", text,
+        "--device", a.device,
+        "--voice", a.voice,
+        "--seed", str(a.seed),
+        "--output", out_path,
+        "--force", "--verbose",
+        "--tts.magpie-model", a.magpie,
+        "--tts.codec-model", a.codec,
+        "--tts.tokenizer-model-dir", a.tokenizer,
+    ]
+    if a.greedy:
+        cmd += ["--top-k", "1"]
+    cmd += a.extra
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        sys.exit(f"synthesize failed:\n{p.stderr[-2000:]}")
+    got = {}
+    for m in METRICS:
+        hit = re.findall(rf"{m}=([0-9.]+)", p.stderr)
+        if hit:
+            got[m] = float(hit[-1])
+    if "e2e_rtf" not in got:
+        sys.exit("no e2e_rtf in output; is this build --verbose capable?")
+    return got
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", required=True)
+    ap.add_argument("--magpie", required=True)
+    ap.add_argument("--codec", required=True)
+    ap.add_argument("--tokenizer", required=True)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--voice", default="John")
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--reps", type=int, default=5)
+    ap.add_argument("--out", default="/tmp/bench_magpietts.wav")
+    ap.add_argument("--label", default="run")
+    ap.add_argument("--json", help="write raw per-run metrics here")
+    ap.add_argument(
+        "--greedy", action="store_true",
+        help="--top-k 1: holds the code sequence fixed and makes output reproducible")
+    ap.add_argument(
+        "--check", action="store_true",
+        help="report the sha256 of each run's WAV instead of timing it")
+    ap.add_argument("--allow-busy-gpu", action="store_true",
+                    help="skip the idle check (results will not be comparable)")
+    ap.add_argument("--extra", nargs=argparse.REMAINDER, default=[],
+                    help="everything after this is passed to synthesize")
+    a = ap.parse_args()
+
+    if not a.allow_busy_gpu and a.device.startswith("cuda") and not wait_idle():
+        sys.exit("GPU never went idle; refusing to benchmark under load")
+
+    if a.check:
+        if not a.greedy:
+            print("warning: --check without --greedy; sampled output need not repeat",
+                  file=sys.stderr)
+        print(f"{a.label}: {a.reps} runs per case, checking reproducibility")
+        failures = 0
+        for name, n in CASES:
+            digests = []
+            for _ in range(a.reps):
+                run_once(a, text_for(n), a.out)
+                digests.append(sha256(a.out))
+            unique = sorted(set(digests))
+            ok = len(unique) == 1
+            failures += not ok
+            print(f"  {name:10s} {'OK  ' if ok else 'FAIL'} "
+                  f"{len(unique)} distinct output(s) over {a.reps} runs")
+            for d in unique:
+                print(f"      {d[:16]}  x{digests.count(d)}")
+        if failures:
+            print(f"{failures} case(s) not reproducible", file=sys.stderr)
+        return 1 if failures else 0
+
+    raw = {}
+    print(f"{a.label}: {a.reps} reps per case, seed {a.seed}"
+          f"{', greedy' if a.greedy else ''}")
+    for name, n in CASES:
+        if not a.allow_busy_gpu and a.device.startswith("cuda"):
+            wait_idle()
+        runs = [run_once(a, text_for(n), a.out) for _ in range(a.reps)]
+        raw[name] = runs
+        med = {m: statistics.median([r[m] for r in runs if m in r])
+               for m in METRICS if any(m in r for r in runs)}
+        print(f"  {name:10s} rtf {med['e2e_rtf']:.4f}"
+              f"   itl {med.get('decoder_itl_avg_ms', float('nan')):.2f} ms"
+              f"   codec_rtfx {med.get('codec_rtfx', float('nan')):.1f}"
+              f"   codec_ttfa {med.get('codec_ttfa_ms', float('nan')):.2f} ms"
+              f"   audio {med.get('e2e_audio_s', float('nan')):.1f} s")
+    if a.json:
+        with open(a.json, "w") as f:
+            json.dump({"label": a.label, "reps": a.reps, "seed": a.seed,
+                       "greedy": a.greedy, "runs": raw}, f, indent=1)
+        print(f"  wrote {a.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tts/bench_magpietts.py
+++ b/scripts/tts/bench_magpietts.py
@@ -86,15 +86,25 @@ def wait_idle(threshold=3, consecutive=4, timeout=600):
 
 def run_once(a, text, out_path):
     cmd = [
-        a.bin, "synthesize", text,
-        "--device", a.device,
-        "--voice", a.voice,
-        "--seed", str(a.seed),
-        "--output", out_path,
-        "--force", "--verbose",
-        "--tts.magpie-model", a.magpie,
-        "--tts.codec-model", a.codec,
-        "--tts.tokenizer-model-dir", a.tokenizer,
+        a.bin,
+        "synthesize",
+        text,
+        "--device",
+        a.device,
+        "--voice",
+        a.voice,
+        "--seed",
+        str(a.seed),
+        "--output",
+        out_path,
+        "--force",
+        "--verbose",
+        "--tts.magpie-model",
+        a.magpie,
+        "--tts.codec-model",
+        a.codec,
+        "--tts.tokenizer-model-dir",
+        a.tokenizer,
     ]
     if a.greedy:
         cmd += ["--top-k", "1"]
@@ -134,15 +144,26 @@ def main():
     ap.add_argument("--label", default="run")
     ap.add_argument("--json", help="write raw per-run metrics here")
     ap.add_argument(
-        "--greedy", action="store_true",
-        help="--top-k 1: holds the code sequence fixed and makes output reproducible")
+        "--greedy",
+        action="store_true",
+        help="--top-k 1: holds the code sequence fixed and makes output reproducible",
+    )
     ap.add_argument(
-        "--check", action="store_true",
-        help="report the sha256 of each run's WAV instead of timing it")
-    ap.add_argument("--allow-busy-gpu", action="store_true",
-                    help="skip the idle check (results will not be comparable)")
-    ap.add_argument("--extra", nargs=argparse.REMAINDER, default=[],
-                    help="everything after this is passed to synthesize")
+        "--check",
+        action="store_true",
+        help="report the sha256 of each run's WAV instead of timing it",
+    )
+    ap.add_argument(
+        "--allow-busy-gpu",
+        action="store_true",
+        help="skip the idle check (results will not be comparable)",
+    )
+    ap.add_argument(
+        "--extra",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="everything after this is passed to synthesize",
+    )
     a = ap.parse_args()
 
     if not a.allow_busy_gpu and a.device.startswith("cuda") and not wait_idle():
@@ -150,8 +171,9 @@ def main():
 
     if a.check:
         if not a.greedy:
-            print("warning: --check without --greedy; sampled output need not repeat",
-                  file=sys.stderr)
+            print(
+                "warning: --check without --greedy; sampled output need not repeat", file=sys.stderr
+            )
         print(f"{a.label}: {a.reps} runs per case, checking reproducibility")
         failures = 0
         for name, n in CASES:
@@ -162,8 +184,10 @@ def main():
             unique = sorted(set(digests))
             ok = len(unique) == 1
             failures += not ok
-            print(f"  {name:10s} {'OK  ' if ok else 'FAIL'} "
-                  f"{len(unique)} distinct output(s) over {a.reps} runs")
+            print(
+                f"  {name:10s} {'OK  ' if ok else 'FAIL'} "
+                f"{len(unique)} distinct output(s) over {a.reps} runs"
+            )
             for d in unique:
                 print(f"      {d[:16]}  x{digests.count(d)}")
         if failures:
@@ -171,24 +195,31 @@ def main():
         return 1 if failures else 0
 
     raw = {}
-    print(f"{a.label}: {a.reps} reps per case, seed {a.seed}"
-          f"{', greedy' if a.greedy else ''}")
+    print(f"{a.label}: {a.reps} reps per case, seed {a.seed}" f"{', greedy' if a.greedy else ''}")
     for name, n in CASES:
         if not a.allow_busy_gpu and a.device.startswith("cuda"):
             wait_idle()
         runs = [run_once(a, text_for(n), a.out) for _ in range(a.reps)]
         raw[name] = runs
-        med = {m: statistics.median([r[m] for r in runs if m in r])
-               for m in METRICS if any(m in r for r in runs)}
-        print(f"  {name:10s} rtf {med['e2e_rtf']:.4f}"
-              f"   itl {med.get('decoder_itl_avg_ms', float('nan')):.2f} ms"
-              f"   codec_rtfx {med.get('codec_rtfx', float('nan')):.1f}"
-              f"   codec_ttfa {med.get('codec_ttfa_ms', float('nan')):.2f} ms"
-              f"   audio {med.get('e2e_audio_s', float('nan')):.1f} s")
+        med = {
+            m: statistics.median([r[m] for r in runs if m in r])
+            for m in METRICS
+            if any(m in r for r in runs)
+        }
+        print(
+            f"  {name:10s} rtf {med['e2e_rtf']:.4f}"
+            f"   itl {med.get('decoder_itl_avg_ms', float('nan')):.2f} ms"
+            f"   codec_rtfx {med.get('codec_rtfx', float('nan')):.1f}"
+            f"   codec_ttfa {med.get('codec_ttfa_ms', float('nan')):.2f} ms"
+            f"   audio {med.get('e2e_audio_s', float('nan')):.1f} s"
+        )
     if a.json:
         with open(a.json, "w") as f:
-            json.dump({"label": a.label, "reps": a.reps, "seed": a.seed,
-                       "greedy": a.greedy, "runs": raw}, f, indent=1)
+            json.dump(
+                {"label": a.label, "reps": a.reps, "seed": a.seed, "greedy": a.greedy, "runs": raw},
+                f,
+                indent=1,
+            )
         print(f"  wrote {a.json}")
     return 0
 

--- a/src/tts/magpietts/magpietts.cpp
+++ b/src/tts/magpietts/magpietts.cpp
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <functional>
 #include <limits>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <random>
@@ -263,8 +262,10 @@ class MagpieStreamingWorkspace {
     DecoderKvCache cond_kv;
     DecoderKvCache uncond_kv;
     DecoderCrossKvCache cond_cross_kv;
+    // Declared after the state: the graph holds nodes pointing at the state's
+    // cache tensors, so it must be destroyed first.
     nc::NanoCodecStreamState codec_stream_state;
-    std::map<int, nc::NanoCodecStreamGraph> codec_stream_graphs;
+    nc::NanoCodecStreamGraph codec_stream_graph;
 
    private:
     MagpieModel local_transformer_cpu_model;
@@ -666,11 +667,17 @@ decode_and_stream_chunk(
             fprintf(stderr, "stateful codec stream requested without a persistent graph\n");
             return false;
         }
-        if (!stream_graph->initialized() ||
-            stream_graph->chunkFrames() != (int)codec_frames.size()) {
-            if (!decoder.initStreamGraph(*stream_state, (int)codec_frames.size(), *stream_graph)) {
-                return false;
-            }
+        if (!stream_graph->initialized()) {
+            fprintf(stderr, "stateful codec stream graph was not initialized\n");
+            return false;
+        }
+        // Short chunks are zero-padded and trimmed inside the decoder, so a partial final
+        // chunk reuses the graph rather than forcing a rebuild.
+        if ((int)codec_frames.size() > stream_graph->chunkFrames()) {
+            fprintf(
+                stderr, "codec chunk has %zu frames, over the graph's %d\n", codec_frames.size(),
+                stream_graph->chunkFrames());
+            return false;
         }
         decoded = decoder.decodeStream(*stream_state, *stream_graph, codec_frames, threads, audio);
     } else {
@@ -742,7 +749,7 @@ struct codec_stream_worker {
     stream_audio_outputs& outputs;
     AudioPostProcessor audio_pp;
     nc::NanoCodecStreamState& stream_state;
-    std::map<int, nc::NanoCodecStreamGraph>& stream_graphs;
+    nc::NanoCodecStreamGraph& stream_graph;
     stream_run_metrics* metrics = nullptr;
     const char* run_label = "stream";
     int chunk_size = 3;
@@ -771,14 +778,13 @@ struct codec_stream_worker {
 
     codec_stream_worker(
         const nc::NanoCodecModel& codec_, nc::NanoCodecDecoder& decoder_,
-        nc::NanoCodecStreamState& stream_state_,
-        std::map<int, nc::NanoCodecStreamGraph>& stream_graphs_, int threads_,
-        stream_audio_outputs& outputs_, int samples_per_frame, int chunk_size_, int history_size_,
-        int future_frames, int window_samples, size_t queue_depth, bool true_stateful_,
-        stream_run_metrics* metrics_, const char* run_label_, bool verbose_)
+        nc::NanoCodecStreamState& stream_state_, nc::NanoCodecStreamGraph& stream_graph_,
+        int threads_, stream_audio_outputs& outputs_, int samples_per_frame, int chunk_size_,
+        int history_size_, int future_frames, int window_samples, size_t queue_depth,
+        bool true_stateful_, stream_run_metrics* metrics_, const char* run_label_, bool verbose_)
         : codec(codec_), decoder(decoder_), threads(threads_), outputs(outputs_),
           audio_pp(samples_per_frame, future_frames, window_samples), stream_state(stream_state_),
-          stream_graphs(stream_graphs_), metrics(metrics_),
+          stream_graph(stream_graph_), metrics(metrics_),
           run_label(run_label_ ? run_label_ : "stream"), chunk_size(std::max(1, chunk_size_)),
           history_size(std::max(0, history_size_)), future_size(std::max(0, future_frames)),
           true_stateful(true_stateful_), verbose(verbose_) {
@@ -976,6 +982,32 @@ struct codec_stream_worker {
         return false;
     }
 
+    // Build the fixed-size graph and push one throwaway chunk through it before any real
+    // tokens arrive. That moves the graph allocation and the backend's first-run graph
+    // capture off the first audio chunk's latency, while the acoustic model is still
+    // generating. The caches are zeroed afterwards, so the stream still starts from silence.
+    bool prewarm() {
+        const ggml_nvtx::range nvtx_range("magpietts_stream_codec_prewarm");
+        // A workspace reused across requests keeps its graph, and with it the backend's
+        // captured version of it; zeroing the caches is all a fresh stream needs.
+        if (stream_graph.initialized() && stream_graph.chunkFrames() == chunk_size) {
+            stream_state.clear();
+            return true;
+        }
+        if (!decoder.initStreamGraph(stream_state, chunk_size, stream_graph)) {
+            set_failed("failed to initialize the codec stream graph");
+            return false;
+        }
+        const nc::NanoCodecFrames warm((size_t)chunk_size, nc::NanoCodecFrame{});
+        std::vector<float> discard;
+        if (!decoder.decodeStream(stream_state, stream_graph, warm, threads, discard)) {
+            set_failed("failed to warm up the codec stream graph");
+            return false;
+        }
+        stream_state.clear();
+        return true;
+    }
+
     void run() {
         const ggml_nvtx::range nvtx_range("magpietts_stream_codec_worker_run");
         if (verbose) {
@@ -983,6 +1015,9 @@ struct codec_stream_worker {
                 stderr,
                 "codec worker started: chunk_size=%d history=%d future=%d max_buffered=%zu\n",
                 chunk_size, history_size, future_size, max_buffered_frames);
+        }
+        if (true_stateful && !prewarm()) {
+            return;
         }
         try {
             for (;;) {
@@ -1000,14 +1035,13 @@ struct codec_stream_worker {
                     }
                     continue;
                 }
-                nc::NanoCodecStreamGraph* stream_graph = nullptr;
-                if (true_stateful) {
-                    stream_graph = &stream_graphs[(int)item.frames.size()];
-                }
+                // Reads are capped at chunk_size and a short final chunk is zero-padded by
+                // the decoder, so one graph serves the whole stream.
+                nc::NanoCodecStreamGraph* graph = true_stateful ? &stream_graph : nullptr;
                 if (!decode_and_stream_chunk(
-                        codec, decoder, true_stateful ? &stream_state : nullptr, stream_graph,
-                        item.frames, threads, outputs, audio_pp, metrics, run_label,
-                        item.chunk_index, item.history_frames, item.final_read, verbose)) {
+                        codec, decoder, true_stateful ? &stream_state : nullptr, graph, item.frames,
+                        threads, outputs, audio_pp, metrics, run_label, item.chunk_index,
+                        item.history_frames, item.final_read, verbose)) {
                     set_failed("decode or audio output failed");
                     return;
                 }
@@ -1189,7 +1223,7 @@ stream_magpie_to_audio(
     }
 
     codec_stream_worker codec_worker(
-        codec, workspace.codec_decoder, workspace.codec_stream_state, workspace.codec_stream_graphs,
+        codec, workspace.codec_decoder, workspace.codec_stream_state, workspace.codec_stream_graph,
         params.codec_threads, outputs, codec.samplesPerFrame(), params.chunk_frames,
         params.codec_history_frames, params.codec_future_frames, window_samples,
         (size_t)params.codec_queue_depth, params.use_stateful_codec, &metrics, label,

--- a/src/tts/nanocodec/model.cpp
+++ b/src/tts/nanocodec/model.cpp
@@ -22,6 +22,8 @@
 #include "nvtx_utils.h"
 
 static constexpr int NANO_CODEC_MAX_NODES = 32768;
+// Upper bound on persistent layer caches: one per causal conv plus one tail per upsampler.
+static constexpr int NANO_CODEC_MAX_CACHES = 512;
 
 using nc_hparams = nemo_speech::tts::nanocodec::NanoCodecHParams;
 
@@ -77,6 +79,10 @@ struct nc_model {
     ggml_context* ctx = nullptr;
     ggml_backend_t backend = nullptr;
     ggml_backend_buffer_t buffer = nullptr;
+
+    // Holds F32 copies of the upsampler kernels on backends that need them; empty otherwise.
+    ggml_context* aux_ctx = nullptr;
+    ggml_backend_buffer_t aux_buffer = nullptr;
 
     nc_conv pre_conv;
     std::vector<nc_activation> activations;
@@ -186,6 +192,104 @@ load_conv(const nc_model& model, const std::string& prefix, int stride = 1, int 
     conv.stride = stride;
     conv.dilation = dilation;
     return conv;
+}
+
+// Whether this backend can convolve with the stored F16 kernel without changing the result.
+//
+// The transposed convolutions are the one place the stored F16 weights meet an op whose
+// backend behaviour varies. CUDA and Metal widen each kernel element to F32 and accumulate
+// in F32, so an F16 kernel is bit-identical to an F32 copy of it. Vulkan rejects a
+// non-F32 kernel outright, and ggml's CPU path pairs an F16 kernel with an F16 rounding of
+// the F32 activations, which loses precision the old F32 copy kept. Those two get a
+// converted copy instead -- made once here rather than on every graph evaluation.
+static bool
+nc_backend_takes_f16_deconv(ggml_backend_t backend, const nc_conv& conv) {
+    if (!backend || !conv.w || ggml_backend_is_cpu(backend)) {
+        return false;
+    }
+    ggml_init_params params = {
+        /*.mem_size   =*/ggml_tensor_overhead() * 8,
+        /*.mem_buffer =*/nullptr,
+        /*.no_alloc   =*/true,
+    };
+    ggml_context* ctx = ggml_init(params);
+    if (!ctx) {
+        return false;
+    }
+    ggml_tensor* input = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 8, conv.w->ne[2], 1);
+    ggml_tensor* probe = ggml_conv_transpose_1d(ctx, conv.w, input, conv.stride, 0, 1);
+    const bool supported = probe && ggml_backend_supports_op(backend, probe);
+    ggml_free(ctx);
+    return supported;
+}
+
+static bool
+nc_prepare_deconv_weights(nc_model& model, bool verbose) {
+    if (model.up_convs.empty()) {
+        return true;
+    }
+    if (nc_backend_takes_f16_deconv(model.backend, model.up_convs.front())) {
+        if (verbose) {
+            fprintf(stderr, "NanoCodec upsampler kernels used as stored (F16)\n");
+        }
+        return true;
+    }
+
+    ggml_init_params params = {
+        /*.mem_size   =*/ggml_tensor_overhead() * (model.up_convs.size() + 2),
+        /*.mem_buffer =*/nullptr,
+        /*.no_alloc   =*/true,
+    };
+    model.aux_ctx = ggml_init(params);
+    if (!model.aux_ctx) {
+        fprintf(stderr, "failed to allocate NanoCodec auxiliary weight context\n");
+        return false;
+    }
+
+    std::vector<ggml_tensor*> converted(model.up_convs.size(), nullptr);
+    for (size_t i = 0; i < model.up_convs.size(); ++i) {
+        const ggml_tensor* src = model.up_convs[i].w;
+        if (src->type == GGML_TYPE_F32) {
+            continue;
+        }
+        converted[i] =
+            ggml_new_tensor_3d(model.aux_ctx, GGML_TYPE_F32, src->ne[0], src->ne[1], src->ne[2]);
+        ggml_set_name(converted[i], (std::string(ggml_get_name(src)) + ".f32").c_str());
+    }
+
+    model.aux_buffer = ggml_backend_alloc_ctx_tensors(model.aux_ctx, model.backend);
+    if (!model.aux_buffer) {
+        fprintf(stderr, "failed to allocate NanoCodec F32 upsampler kernels\n");
+        return false;
+    }
+
+    std::vector<ggml_fp16_t> src_half;
+    std::vector<float> dst_full;
+    for (size_t i = 0; i < converted.size(); ++i) {
+        if (!converted[i]) {
+            continue;
+        }
+        ggml_tensor* src = model.up_convs[i].w;
+        if (src->type != GGML_TYPE_F16) {
+            fprintf(stderr, "unsupported upsampler kernel type %s\n", ggml_type_name(src->type));
+            return false;
+        }
+        const size_t n = (size_t)ggml_nelements(src);
+        src_half.resize(n);
+        dst_full.resize(n);
+        ggml_backend_tensor_get(src, src_half.data(), 0, n * sizeof(ggml_fp16_t));
+        ggml_fp16_to_fp32_row(src_half.data(), dst_full.data(), (int64_t)n);
+        ggml_backend_tensor_set(converted[i], dst_full.data(), 0, n * sizeof(float));
+        model.up_convs[i].w = converted[i];
+    }
+
+    if (verbose) {
+        fprintf(
+            stderr, "NanoCodec upsampler kernels converted to F32 (%.1f MiB) for backend %s\n",
+            (double)ggml_backend_buffer_get_size(model.aux_buffer) / (1024.0 * 1024.0),
+            ggml_backend_name(model.backend));
+    }
+    return true;
 }
 
 static bool
@@ -317,6 +421,10 @@ nc_model_load(
     model.post_activation = load_activation(model, "dec.post_act");
     model.post_conv = load_conv(model, "dec.post");
 
+    if (!nc_prepare_deconv_weights(model, verbose)) {
+        return false;
+    }
+
     if (verbose) {
         fprintf(
             stderr,
@@ -329,6 +437,14 @@ nc_model_load(
 
 static void
 nc_model_free(nc_model& model) {
+    if (model.aux_buffer) {
+        ggml_backend_buffer_free(model.aux_buffer);
+        model.aux_buffer = nullptr;
+    }
+    if (model.aux_ctx) {
+        ggml_free(model.aux_ctx);
+        model.aux_ctx = nullptr;
+    }
     if (model.buffer) {
         ggml_backend_buffer_free(model.buffer);
         model.buffer = nullptr;
@@ -372,10 +488,11 @@ causal_conv1d(ggml_context* ctx, ggml_tensor* x, const nc_conv& conv) {
 static ggml_tensor*
 causal_conv_transpose1d(ggml_context* ctx, ggml_tensor* x, const nc_conv& conv) {
     const int64_t out_len = x->ne[0] * conv.stride;
-    ggml_tensor* weight = ggml_cont(ctx, ggml_cast(ctx, conv.w, GGML_TYPE_F32));
-    ggml_tensor* full = ggml_conv_transpose_1d(ctx, weight, x, conv.stride, 0, 1);
+    // The kernel is already in a type this backend convolves with directly; any conversion
+    // the backend needed happened once at load time.
+    ggml_tensor* full = ggml_conv_transpose_1d(ctx, conv.w, x, conv.stride, 0, 1);
     ggml_tensor* cropped =
-        ggml_view_3d(ctx, full, out_len, weight->ne[1], 1, full->nb[1], full->nb[2], 0);
+        ggml_view_3d(ctx, full, out_len, conv.w->ne[1], 1, full->nb[1], full->nb[2], 0);
     return ggml_add(ctx, cropped, conv.b);
 }
 
@@ -486,21 +603,15 @@ enum nc_stream_cache_kind {
     NC_STREAM_CACHE_DECONV = 1,
 };
 
-struct nc_stream_cache {
-    int64_t len = 0;
-    int64_t channels = 0;
-    std::vector<float> data;
-};
-
-struct nc_stream_pending_tensor {
-    ggml_tensor* tensor = nullptr;
-    nc_stream_cache_kind kind = NC_STREAM_CACHE_CONV;
-    size_t index = 0;
+// One refresh of a layer cache. `barrier` is the last graph node that reads the cache;
+// expanding it before `write` keeps the copy ordered after every read of the old value.
+struct nc_stream_cache_write {
+    ggml_tensor* barrier = nullptr;
+    ggml_tensor* write = nullptr;
 };
 
 struct nc_stream_graph_io {
-    std::vector<nc_stream_pending_tensor> inputs;
-    std::vector<nc_stream_pending_tensor> outputs;
+    std::vector<nc_stream_cache_write> cache_writes;
 };
 
 struct nc_stream_decode_graph {
@@ -517,21 +628,41 @@ struct nc_stream_decode_graph {
     std::vector<float> audio_data;
 };
 
+// Layer state lives in backend memory for the lifetime of the stream. The decode graph
+// reads each cache in place and writes the next value back with ggml_cpy, so decoding a
+// chunk never round-trips conv state through the host.
+//
+// The tensors are created while the graph is built and the graph nodes point straight at
+// them, so a state backs exactly one graph: re-initializing a graph resets the state, and
+// the graph must be destroyed before the state it was built against.
 struct nc_stream_state {
-    std::vector<nc_stream_cache> conv_caches;
-    std::vector<nc_stream_cache> deconv_tails;
-    size_t conv_pos = 0;
-    size_t deconv_pos = 0;
+    ggml_context* ctx = nullptr;
+    ggml_backend_buffer_t buffer = nullptr;
+    std::vector<ggml_tensor*> caches;
 
-    void begin_graph() {
-        conv_pos = 0;
-        deconv_pos = 0;
+    nc_stream_state() = default;
+    ~nc_stream_state() { free_tensors(); }
+
+    nc_stream_state(const nc_stream_state&) = delete;
+    nc_stream_state& operator=(const nc_stream_state&) = delete;
+
+    void free_tensors() {
+        if (buffer) {
+            ggml_backend_buffer_free(buffer);
+            buffer = nullptr;
+        }
+        if (ctx) {
+            ggml_free(ctx);
+            ctx = nullptr;
+        }
+        caches.clear();
     }
 
+    // Reset the stream to silence without discarding the graph built against these tensors.
     void clear() {
-        conv_caches.clear();
-        deconv_tails.clear();
-        begin_graph();
+        if (buffer) {
+            ggml_backend_buffer_clear(buffer, 0);
+        }
     }
 };
 
@@ -568,53 +699,27 @@ nc_stream_decode_graph_free(nc_stream_decode_graph& graph) {
     graph.audio_data.clear();
 }
 
-static nc_stream_cache&
-nc_stream_cache_at(
-    std::vector<nc_stream_cache>& caches, size_t index, int64_t len, int64_t channels) {
-    if (index >= caches.size()) {
-        caches.resize(index + 1);
-    }
-    nc_stream_cache& cache = caches[index];
-    if (cache.len != len || cache.channels != channels ||
-        cache.data.size() != (size_t)(len * channels)) {
-        cache.len = len;
-        cache.channels = channels;
-        cache.data.assign((size_t)(len * channels), 0.0f);
-    }
-    return cache;
-}
-
-static nc_stream_cache&
-nc_stream_get_or_create_cache(nc_stream_state& state, const nc_stream_pending_tensor& pending) {
-    const int64_t len = pending.tensor ? pending.tensor->ne[0] : 0;
-    const int64_t channels = pending.tensor ? pending.tensor->ne[1] : 0;
-    if (pending.kind == NC_STREAM_CACHE_CONV) {
-        return nc_stream_cache_at(state.conv_caches, pending.index, len, channels);
-    }
-    return nc_stream_cache_at(state.deconv_tails, pending.index, len, channels);
-}
-
+// Allocate one persistent layer cache in the state's own context. The tensors are backed
+// by a backend buffer once the whole graph is built, before the graph allocator runs, so
+// the allocator treats them as pre-allocated leaves and never reuses their memory.
 static ggml_tensor*
 nc_stream_cache_tensor(
-    ggml_context* ctx, nc_stream_state& state, nc_stream_graph_io& io, nc_stream_cache_kind kind,
-    size_t index, int64_t len, int64_t channels) {
-    if (kind == NC_STREAM_CACHE_CONV) {
-        nc_stream_cache_at(state.conv_caches, index, len, channels);
-    } else {
-        nc_stream_cache_at(state.deconv_tails, index, len, channels);
-    }
-
-    ggml_tensor* tensor = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, len, channels, 1);
+    nc_stream_state& state, nc_stream_cache_kind kind, int64_t len, int64_t channels) {
+    ggml_tensor* tensor = ggml_new_tensor_3d(state.ctx, GGML_TYPE_F32, len, channels, 1);
     ggml_set_input(tensor);
-    io.inputs.push_back({tensor, kind, index});
+    const std::string name = (kind == NC_STREAM_CACHE_CONV ? "nc_conv_cache_" : "nc_deconv_tail_") +
+                             std::to_string(state.caches.size());
+    ggml_set_name(tensor, name.c_str());
+    state.caches.push_back(tensor);
     return tensor;
 }
 
+// Refresh `cache` from `next` once `barrier` -- the last node reading the old value -- has run.
 static void
-nc_stream_add_cache_output(
-    nc_stream_graph_io& io, ggml_tensor* tensor, nc_stream_cache_kind kind, size_t index) {
-    ggml_set_output(tensor);
-    io.outputs.push_back({tensor, kind, index});
+nc_stream_write_cache(
+    ggml_context* ctx, nc_stream_graph_io& io, ggml_tensor* barrier, ggml_tensor* next,
+    ggml_tensor* cache) {
+    io.cache_writes.push_back({barrier, ggml_cpy(ctx, next, cache)});
 }
 
 static ggml_tensor*
@@ -626,17 +731,16 @@ nc_stream_causal_conv1d(
     ggml_tensor* conv_in = x;
 
     if (left_pad > 0) {
-        const size_t cache_index = state.conv_pos++;
-        ggml_tensor* cache = nc_stream_cache_tensor(
-            ctx, state, io, NC_STREAM_CACHE_CONV, cache_index, left_pad, x->ne[1]);
+        ggml_tensor* cache =
+            nc_stream_cache_tensor(state, NC_STREAM_CACHE_CONV, left_pad, x->ne[1]);
         conv_in = ggml_concat(ctx, cache, x, 0);
 
         const int64_t tail_start = conv_in->ne[0] - left_pad;
         ggml_tensor* tail = ggml_view_3d(
             ctx, conv_in, left_pad, x->ne[1], 1, conv_in->nb[1], conv_in->nb[2],
             (size_t)tail_start * conv_in->nb[0]);
-        tail = ggml_cont_3d(ctx, tail, left_pad, x->ne[1], 1);
-        nc_stream_add_cache_output(io, tail, NC_STREAM_CACHE_CONV, cache_index);
+        // The concat is the only reader of `cache`, so the refresh may follow it directly.
+        nc_stream_write_cache(ctx, io, conv_in, tail, cache);
     }
 
     ggml_tensor* y = ggml_conv_1d(ctx, conv.w, conv_in, conv.stride, 0, conv.dilation);
@@ -649,15 +753,13 @@ nc_stream_causal_conv_transpose1d(
     ggml_context* ctx, ggml_tensor* x, const nc_conv& conv, nc_stream_state& state,
     nc_stream_graph_io& io) {
     const int64_t out_len = x->ne[0] * conv.stride;
-    ggml_tensor* weight = ggml_cont(ctx, ggml_cast(ctx, conv.w, GGML_TYPE_F32));
-    ggml_tensor* full = ggml_conv_transpose_1d(ctx, weight, x, conv.stride, 0, 1);
+    ggml_tensor* full = ggml_conv_transpose_1d(ctx, conv.w, x, conv.stride, 0, 1);
     const int64_t tail_len = std::max<int64_t>(0, full->ne[0] - out_len);
 
     ggml_tensor* current = nullptr;
     if (tail_len > 0) {
-        const size_t tail_index = state.deconv_pos++;
-        ggml_tensor* prev_tail = nc_stream_cache_tensor(
-            ctx, state, io, NC_STREAM_CACHE_DECONV, tail_index, tail_len, full->ne[1]);
+        ggml_tensor* prev_tail =
+            nc_stream_cache_tensor(state, NC_STREAM_CACHE_DECONV, tail_len, full->ne[1]);
 
         const int64_t add_len = std::min<int64_t>(tail_len, out_len);
         ggml_tensor* prefix =
@@ -682,8 +784,8 @@ nc_stream_causal_conv_transpose1d(
         ggml_tensor* next_tail = ggml_view_3d(
             ctx, full, tail_len, full->ne[1], 1, full->nb[1], full->nb[2],
             (size_t)out_len * full->nb[0]);
-        next_tail = ggml_cont_3d(ctx, next_tail, tail_len, full->ne[1], 1);
-        nc_stream_add_cache_output(io, next_tail, NC_STREAM_CACHE_DECONV, tail_index);
+        // `current` descends from the add that consumes the old tail, so it is the barrier.
+        nc_stream_write_cache(ctx, io, current, next_tail, prev_tail);
     } else {
         current = ggml_view_3d(ctx, full, out_len, conv.w->ne[1], 1, full->nb[1], full->nb[2], 0);
     }
@@ -880,7 +982,22 @@ nc_stream_decode_graph_init(
         return false;
     }
 
-    state.begin_graph();
+    // The graph nodes will point straight at the state tensors, so the previous state is
+    // discarded together with the previous graph and the stream restarts from silence.
+    state.free_tensors();
+    {
+        ggml_init_params cache_params = {
+            /*.mem_size   =*/ggml_tensor_overhead() * NANO_CODEC_MAX_CACHES,
+            /*.mem_buffer =*/nullptr,
+            /*.no_alloc   =*/true,
+        };
+        state.ctx = ggml_init(cache_params);
+    }
+    if (!state.ctx) {
+        fprintf(stderr, "failed to allocate stream cache context\n");
+        nc_stream_decode_graph_free(graph);
+        return false;
+    }
 
     {
         const ggml_nvtx::range nvtx_build("nanocodec_stream_build_persistent_decoder_graph");
@@ -904,12 +1021,34 @@ nc_stream_decode_graph_init(
         graph.audio = x;
 
         graph.gf = ggml_new_graph_custom(graph.ctx, NANO_CODEC_MAX_NODES, false);
-        for (const nc_stream_pending_tensor& pending : graph.io.outputs) {
-            ggml_build_forward_expand(graph.gf, pending.tensor);
+        // Expanding each barrier before its write keeps every cache refresh ordered after
+        // the node that reads the old value, while still letting the refreshes interleave
+        // with the forward pass so the allocator can recycle activation buffers early.
+        for (const nc_stream_cache_write& refresh : graph.io.cache_writes) {
+            ggml_build_forward_expand(graph.gf, refresh.barrier);
+            ggml_build_forward_expand(graph.gf, refresh.write);
         }
         ggml_build_forward_expand(graph.gf, graph.audio);
         tag_graph_first_node(graph.gf);
     }
+
+    if ((int)state.caches.size() > NANO_CODEC_MAX_CACHES) {
+        fprintf(
+            stderr, "stream graph needs %zu layer caches, over the %d limit\n", state.caches.size(),
+            NANO_CODEC_MAX_CACHES);
+        nc_stream_decode_graph_free(graph);
+        return false;
+    }
+
+    // Back the caches before the graph allocator runs so it sees them as pre-allocated
+    // leaves and never hands their memory to an intermediate tensor.
+    state.buffer = ggml_backend_alloc_ctx_tensors(state.ctx, model.backend);
+    if (!state.buffer) {
+        fprintf(stderr, "failed to allocate stream layer caches on the backend\n");
+        nc_stream_decode_graph_free(graph);
+        return false;
+    }
+    state.clear();
 
     graph.allocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(model.backend));
     if (!graph.allocr) {
@@ -957,6 +1096,12 @@ decode_eval_stream(
         fprintf(stderr, "persistent stream graph is not initialized\n");
         return false;
     }
+    // The graph nodes point at this state's cache tensors; a state that was reset or paired
+    // with a different graph would leave those reads dangling.
+    if (!state.buffer || state.caches.size() != graph.io.cache_writes.size()) {
+        fprintf(stderr, "stream state does not back the persistent stream graph\n");
+        return false;
+    }
     if ((int)frames.size() > graph.chunk_frames) {
         fprintf(
             stderr, "stream chunk has %zu frames, larger than fixed graph chunk_frames=%d\n",
@@ -973,16 +1118,11 @@ decode_eval_stream(
     }
 
     {
+        // The layer caches stay in backend memory across chunks, so the latent is the only
+        // input the host has to upload.
         const ggml_nvtx::range nvtx_inputs("nanocodec_stream_graph_set_inputs");
         ggml_backend_tensor_set(
             graph.latent, graph.latent_data.data(), 0, graph.latent_data.size() * sizeof(float));
-        for (const nc_stream_pending_tensor& pending : graph.io.inputs) {
-            nc_stream_cache& cache = nc_stream_get_or_create_cache(state, pending);
-            if (!cache.data.empty()) {
-                ggml_backend_tensor_set(
-                    pending.tensor, cache.data.data(), 0, cache.data.size() * sizeof(float));
-            }
-        }
     }
 
     if (ggml_backend_is_cpu(model.backend)) {
@@ -1000,15 +1140,8 @@ decode_eval_stream(
     }
 
     {
+        // The graph refreshed the layer caches in place, so only the audio comes back.
         const ggml_nvtx::range nvtx_outputs("nanocodec_stream_graph_get_outputs");
-        for (const nc_stream_pending_tensor& pending : graph.io.outputs) {
-            nc_stream_cache& cache = nc_stream_get_or_create_cache(state, pending);
-            if (!cache.data.empty()) {
-                ggml_backend_tensor_get(
-                    pending.tensor, cache.data.data(), 0, cache.data.size() * sizeof(float));
-            }
-        }
-
         ggml_backend_tensor_get(
             graph.audio, graph.audio_data.data(), 0, graph.audio_data.size() * sizeof(float));
     }

--- a/src/tts/nanocodec/model.cpp
+++ b/src/tts/nanocodec/model.cpp
@@ -247,14 +247,33 @@ nc_prepare_deconv_weights(nc_model& model, bool verbose) {
     }
 
     std::vector<ggml_tensor*> converted(model.up_convs.size(), nullptr);
+    size_t pending = 0;
     for (size_t i = 0; i < model.up_convs.size(); ++i) {
         const ggml_tensor* src = model.up_convs[i].w;
         if (src->type == GGML_TYPE_F32) {
             continue;
         }
+        // Reject an unsupported type before reserving anything for it.
+        if (src->type != GGML_TYPE_F16) {
+            fprintf(stderr, "unsupported upsampler kernel type %s\n", ggml_type_name(src->type));
+            return false;
+        }
         converted[i] =
             ggml_new_tensor_3d(model.aux_ctx, GGML_TYPE_F32, src->ne[0], src->ne[1], src->ne[2]);
         ggml_set_name(converted[i], (std::string(ggml_get_name(src)) + ".f32").c_str());
+        ++pending;
+    }
+
+    // A backend that will not take F16 kernels but whose model already stores them as F32
+    // leaves nothing to convert. ggml_backend_alloc_ctx_tensors returns NULL for an empty
+    // context, which is success here, not a failure to allocate.
+    if (pending == 0) {
+        ggml_free(model.aux_ctx);
+        model.aux_ctx = nullptr;
+        if (verbose) {
+            fprintf(stderr, "NanoCodec upsampler kernels already stored as F32\n");
+        }
+        return true;
     }
 
     model.aux_buffer = ggml_backend_alloc_ctx_tensors(model.aux_ctx, model.backend);
@@ -270,10 +289,6 @@ nc_prepare_deconv_weights(nc_model& model, bool verbose) {
             continue;
         }
         ggml_tensor* src = model.up_convs[i].w;
-        if (src->type != GGML_TYPE_F16) {
-            fprintf(stderr, "unsupported upsampler kernel type %s\n", ggml_type_name(src->type));
-            return false;
-        }
         const size_t n = (size_t)ggml_nelements(src);
         src_half.resize(n);
         dst_full.resize(n);
@@ -614,6 +629,9 @@ struct nc_stream_graph_io {
     std::vector<nc_stream_cache_write> cache_writes;
 };
 
+// Defined below; the graph only records which state owns its cache tensors.
+struct nc_stream_state;
+
 struct nc_stream_decode_graph {
     ggml_context* ctx = nullptr;
     ggml_cgraph* gf = nullptr;
@@ -621,6 +639,9 @@ struct nc_stream_decode_graph {
     ggml_tensor* latent = nullptr;
     ggml_tensor* audio = nullptr;
     nc_stream_graph_io io;
+    // The state whose cache tensors these nodes point at. A different state with the same
+    // cache count would otherwise pass the check below and read freed tensors.
+    const nc_stream_state* owner = nullptr;
     int chunk_frames = 0;
     size_t output_samples = 0;
     size_t samples_per_frame = 0;
@@ -692,6 +713,7 @@ nc_stream_decode_graph_free(nc_stream_decode_graph& graph) {
     graph.latent = nullptr;
     graph.audio = nullptr;
     graph.io = {};
+    graph.owner = nullptr;
     graph.chunk_frames = 0;
     graph.output_samples = 0;
     graph.samples_per_frame = 0;
@@ -987,7 +1009,9 @@ nc_stream_decode_graph_init(
     state.free_tensors();
     {
         ggml_init_params cache_params = {
-            /*.mem_size   =*/ggml_tensor_overhead() * NANO_CODEC_MAX_CACHES,
+            // One over the limit: nc_stream_cache_tensor can create the cache that trips
+            // the post-build check, and an exhausted pool aborts rather than reporting.
+            /*.mem_size   =*/ggml_tensor_overhead() * (NANO_CODEC_MAX_CACHES + 1),
             /*.mem_buffer =*/nullptr,
             /*.no_alloc   =*/true,
         };
@@ -1075,6 +1099,9 @@ nc_stream_decode_graph_init(
         return false;
     }
 
+    // Every node above points at this state's cache tensors; record it so a later decode
+    // cannot pair the graph with a different state that happens to hold as many caches.
+    graph.owner = &state;
     graph.samples_per_frame = graph.output_samples / (size_t)chunk_frames;
     graph.latent_data.assign((size_t)chunk_frames * h.latent_dim, 0.0f);
     graph.audio_data.resize(graph.output_samples);
@@ -1098,7 +1125,8 @@ decode_eval_stream(
     }
     // The graph nodes point at this state's cache tensors; a state that was reset or paired
     // with a different graph would leave those reads dangling.
-    if (!state.buffer || state.caches.size() != graph.io.cache_writes.size()) {
+    if (!state.buffer || graph.owner != &state ||
+        state.caches.size() != graph.io.cache_writes.size()) {
         fprintf(stderr, "stream state does not back the persistent stream graph\n");
         return false;
     }


### PR DESCRIPTION
The streaming decoder marshals all 97 layer caches through the host between
chunks: a device-to-host copy per cache after every chunk, and a host-to-device
copy per cache before the next. At the default 4-frame chunk that is ~196
blocking copies per chunk, and almost none of it is bandwidth — the caches are a
few KB each, so the cost is per-copy `cudaStreamSynchronize` latency.

Profiled on a five-sentence paragraph, the codec worker thread issues **26,862
`cudaMemcpyAsync` and 26,989 `cudaStreamSynchronize` calls to launch 1,330
kernels** — 678 ms of marshalling around a small amount of compute.

## The change

The caches now live in a backend buffer for the lifetime of the stream. The
decode graph reads each one in place and writes the next value back with
`ggml_cpy`, ordered after the node that reads the old value, so a chunk uploads
only the latent and reads back only the audio.

Two smaller changes come with it:

- The upsampler kernels were cast F16→F32 *inside the graph*, so 7.7M weights
  were reconverted on every chunk. That now happens once at load, and only where
  it changes the result: CUDA and Metal widen an F16 kernel to F32 and
  accumulate in F32, so they use the weights as stored, while Vulkan (which
  rejects a non-F32 kernel) and the CPU path (which would round activations to
  F16 as well) get a converted copy.
- One fixed-size graph now serves the stream, built and run once up front so the
  first-run capture is off the first chunk.

## Results

GB300, v2602 f16, greedy, median of 5 runs per case on an idle-gated GPU.
**Both arms carry the half_snake aliasing guard** — see Correctness.

| case | e2e RTF | | codec RTFx | |
|---|---|---|---|---|
| line | 0.0431 → **0.0413** | −4.2% | 33.7 → **68.1** | **2.02×** |
| paragraph | 0.0400 → **0.0395** | −1.3% | 38.4 → **70.0** | **1.82×** |
| script | 0.0401 → **0.0395** | −1.5% | 38.8 → **70.1** | **1.81×** |

**The e2e number is small and that is the honest framing.** The codec runs on a
worker thread and the acoustic model still sets the pace, so 1.3–4.2% is all
that surfaces end to end. What this actually buys is throughput headroom and
latency: codec time-to-first-audio is 2.88 ms, and the codec no longer caps the
system at RTFx ~39 — which is what matters the moment the decoder gets faster
(batched long-form decode, for instance, reaches RTFx ~48 and would otherwise
run straight into that ceiling).

By CUDA API call, same paragraph:

| | before | after | |
|---|---|---|---|
| `cudaMemcpyAsync` | 34,194 | 7,409 | **−78%** |
| `cudaStreamSynchronize` | 29,332 | 2,567 | **−91%** |

## Correctness

This reshapes the codec graph, which changes what the graph allocator does — and
that surfaced something that has to be said first: **`main` is not currently
reproducible.** Three greedy runs of the same script on stock `a5b6953` give
three different WAVs. It was reproducible at `69d7fd4`. Full evidence is in
[#28](https://github.com/NVIDIA/NeMo-Speech.cpp/pull/28#issuecomment-5606816631).

With that guard applied and nothing else, stock `main` is deterministic again
and reproduces `69d7fd4`'s output byte for byte. That is the reference this
change is measured against:

| case | SNR | max diff | differing samples | first difference |
|---|---|---|---|---|
| line (2.74 s) | 73.8 dB | 4 LSB | 1.01% | 139 ms from the end |
| paragraph (25.4 s) | — | — | **byte-identical** | — |
| script (100.0 s) | 92.2 dB | 6 LSB | 0.02% | 60 ms from the end |

Every differing sample is in the final partial chunk, whose padding and trim
this change alters; 4–6 LSB out of 32768 is inaudible. Three runs of each case
are byte-identical to each other.

**So the guard is a prerequisite for measuring anything on the codec path, not a
consequence of this change.** It is not included here — this PR should land
after #28.

## Benchmark script

`scripts/tts/bench_magpietts.py` is included so the numbers above can be
reproduced. Two properties of this pipeline make a naive harness misleading, and
it handles both:

- **`--greedy` for any A/B.** Sampled decoding picks a different code sequence
  when anything perturbs the arithmetic, which changes audio *duration*, which
  moves RTF on its own — an A/B can show a difference that is entirely one arm
  producing 2.7 s and the other 3.0 s.
- **The GPU must be idle.** A background job moves these numbers by 2–4×, so it
  refuses to start until `nvidia-smi` reports ≤ 3% for four consecutive samples,
  and re-checks between cases.

```
$ scripts/tts/bench_magpietts.py --bin build/cuda-speech/bin/nemo-speech \
    --magpie MAGPIE.gguf --codec CODEC.gguf --tokenizer TOKENIZER_DIR --greedy

codec-device-state: 5 reps per case, seed 7, greedy
  line       rtf 0.0413   itl 1.75 ms   codec_rtfx 68.1   codec_ttfa 2.88 ms   audio 2.7 s
  paragraph  rtf 0.0395   itl 1.72 ms   codec_rtfx 70.0   codec_ttfa 2.88 ms   audio 25.4 s
  script     rtf 0.0395   itl 1.71 ms   codec_rtfx 70.1   codec_ttfa 2.90 ms   audio 100.0 s
```

`--check` skips timing and reports the sha256 of each run's WAV instead. Under
`--greedy` every run must produce the same hash; stock `main` currently fails
this, which is how the reproducibility problem above was found.

```
$ scripts/tts/bench_magpietts.py ... --greedy --check --reps 3
  line       OK   1 distinct output(s) over 3 runs
      63c2caa1f3de4791  x3
  paragraph  OK   1 distinct output(s) over 3 runs
      854310de09b63ac4  x3
  script     OK   1 distinct output(s) over 3 runs
      97a6a9647628af94  x3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a MagpieTTS benchmarking tool with configurable synthesis settings, repeated timing runs, performance metrics, optional JSON output, and reproducibility checks.

- **Improvements**
  - Improved streaming speech generation efficiency by reusing decoding resources across audio chunks.
  - Enhanced handling of variable-length audio chunks, including shorter final chunks.
  - Improved compatibility and performance across supported processing backends.
  - Reduced unnecessary data transfers during streaming audio decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->