### PR TITLE
fix(asr): make mid-stream EOU a soft reporting checkpoint, not a hard reset

### DIFF
--- a/src/asr/runner.cpp
+++ b/src/asr/runner.cpp
@@ -1041,37 +1041,12 @@ CacheStreamRunner::step() {
 
 void
 CacheStreamRunner::finish_endpoint(StreamingUpdate& update) {
-    // A mid-stream EOU is a *reporting* boundary, not an audio-stream
-    // boundary -- see this method's declaration doc comment. It used to also
-    // hard-reset encoder cache and predictor state (Decoder::reset(),
-    // zero_caches(), cache_filled_frames_, attn_mask_) and flush a
-    // zero-padded synthetic tail through the finalizing_ (is_last) path to
-    // resolve trailing subwords early. Both are deliberately gone now:
-    //
-    // - The hard reset destroyed the model's acoustic/linguistic context
-    //   right at the boundary, so the next segment decoded as if it were a
-    //   brand new, context-free utterance -- wrong capitalization and (per
-    //   the finalizing_ EOU punctuation floor below) a spurious terminal
-    //   '.'/'?' that has nothing to do with the actual grammar.
-    // - The synthetic zero-pad tail flush exists to give the encoder extra
-    //   right-context lookahead for words it hasn't fully resolved yet (see
-    //   finalize()'s identical technique for genuine end-of-stream). That's
-    //   only needed because the old code was about to reset state and lose
-    //   the chance to keep decoding; without a reset, real subsequent audio
-    //   keeps arriving and resolves any still-open word exactly the way it
-    //   already does everywhere else in this runner (see
-    //   process_one_chunk/step) -- no synthetic frames required.
-    // - `finalizing_`/set_finalizing(true) specifically biases the RNNT head
-    //   to float a marginal terminal '.'/'?' logit above blank (see
-    //   RnntGreedyDecoder's punct-bias comment) -- appropriate at a genuine
-    //   end of stream, wrong here: an ordinary mid-utterance pause is not
-    //   grammatically "the end of a sentence," and forcing punctuation there
-    //   is exactly the class of bug this fix removes.
-    //
-    // fire_eou's own Decoder::reset_utterance() (not reset()) already is the
-    // right-sized reset for a checkpoint like this: see reset_utterance()'s
-    // doc comment -- "soft utterance reset for callers that intentionally
-    // preserve predictor context."
+    // Used to also hard-reset encoder cache/predictor state and flush a
+    // synthetic zero-padded tail (which biases the RNNT head toward a
+    // terminal '.'/'?'). Both removed: an ordinary mid-sentence pause isn't
+    // a real utterance end, so it shouldn't wipe context or force
+    // punctuation. fire_eou's Decoder::reset_utterance() is already the
+    // right-sized reset for a checkpoint like this.
     fire_eou(head_.get(), opts_, all_tokens_, transcript_, update);
 }
 

--- a/src/asr/runner.cpp
+++ b/src/asr/runner.cpp
@@ -844,10 +844,8 @@ CacheStreamRunner::set_request_options(const AsrRequestOptions& opts) {
 
 void
 CacheStreamRunner::force_eou() {
-    if (endpointer_) {
-        force_eou_pending_ = true;
+    if (endpointer_)
         endpointer_->force();
-    }
 }
 
 void
@@ -1022,7 +1020,7 @@ CacheStreamRunner::step() {
             stream_zero_padded_ = true;
         }
         process_one_chunk(/*is_last=*/false);
-        if (poll_endpoint(update, /*after_chunk=*/true))
+        if (poll_endpoint(update))
             break;
     }
     update.new_token_ids = last_step_new_tokens_;
@@ -1034,7 +1032,7 @@ CacheStreamRunner::step() {
         static_cast<float>(audio_end) / static_cast<float>(model_->fe_config().sample_rate);
     // A pending force_eou() must fire even on a chunk-less step.
     if (!update.is_final)
-        poll_endpoint(update, /*after_chunk=*/false);
+        poll_endpoint(update);
     if (!update.is_final && opts_.needs_word_timings() && head_)
         update.words = head_->word_timings();
     trim_buffers();
@@ -1042,67 +1040,43 @@ CacheStreamRunner::step() {
 }
 
 void
-CacheStreamRunner::finish_endpoint(StreamingUpdate& update, bool preserve_buffered_future) {
-    compact_mel_buffer();
-    const int n_mels = model_->fe_config().n_mels;
-    const int sub = enc_cfg_.subsampling_factor;
-    const int R = enc_cfg_.cache_right_ctx;
-    const int chunk_size_mel = pre_encode_cache_size_ + sub * (1 + R);
-    const int shift_size_mel = sub * (1 + R - cache_drop_size_);
-
-    // After a decoded chunk, mel_buf_ starts with the encoder overlap. Frames
-    // beyond it have not been decoded and belong to the next utterance when
-    // endpointing fired automatically. A forced EOU instead commits all audio
-    // already supplied by the caller.
-    std::vector<float> next_mel;
-    if (preserve_buffered_future) {
-        const int overlap_frames = chunk_size_mel - shift_size_mel;
-        const size_t split = std::min(
-            mel_buf_.size(), static_cast<size_t>(overlap_frames) * static_cast<size_t>(n_mels));
-        next_mel.assign(mel_buf_.begin() + split, mel_buf_.end());
-        mel_buf_.resize(split);
-    }
-
-    // Flush the acoustic tail through the same EOS path as finalize(). The
-    // synthetic frames may commit terminal punctuation, but they must not
-    // advance the stream clock used by the next utterance.
-    const int64_t real_frames_emitted = total_frames_emitted_;
-    const int real_chunks_processed = chunks_processed_;
-    finalizing_ = true;
-    if (!mel_buf_.empty()) {
-        if (!stream_zero_padded_) {
-            mel_buf_.insert(
-                mel_buf_.begin(), static_cast<size_t>(pre_encode_cache_size_) * n_mels, 0.0f);
-            stream_zero_padded_ = true;
-        }
-        const size_t flush_frames = static_cast<size_t>(chunk_size_mel + shift_size_mel);
-        mel_buf_.resize(mel_buf_.size() + flush_frames * static_cast<size_t>(n_mels), 0.0f);
-        while (static_cast<int>((mel_buf_.size() - mel_offset_) / n_mels) >= chunk_size_mel)
-            process_one_chunk(/*is_last=*/true);
-    }
-
+CacheStreamRunner::finish_endpoint(StreamingUpdate& update) {
+    // A mid-stream EOU is a *reporting* boundary, not an audio-stream
+    // boundary -- see this method's declaration doc comment. It used to also
+    // hard-reset encoder cache and predictor state (Decoder::reset(),
+    // zero_caches(), cache_filled_frames_, attn_mask_) and flush a
+    // zero-padded synthetic tail through the finalizing_ (is_last) path to
+    // resolve trailing subwords early. Both are deliberately gone now:
+    //
+    // - The hard reset destroyed the model's acoustic/linguistic context
+    //   right at the boundary, so the next segment decoded as if it were a
+    //   brand new, context-free utterance -- wrong capitalization and (per
+    //   the finalizing_ EOU punctuation floor below) a spurious terminal
+    //   '.'/'?' that has nothing to do with the actual grammar.
+    // - The synthetic zero-pad tail flush exists to give the encoder extra
+    //   right-context lookahead for words it hasn't fully resolved yet (see
+    //   finalize()'s identical technique for genuine end-of-stream). That's
+    //   only needed because the old code was about to reset state and lose
+    //   the chance to keep decoding; without a reset, real subsequent audio
+    //   keeps arriving and resolves any still-open word exactly the way it
+    //   already does everywhere else in this runner (see
+    //   process_one_chunk/step) -- no synthetic frames required.
+    // - `finalizing_`/set_finalizing(true) specifically biases the RNNT head
+    //   to float a marginal terminal '.'/'?' logit above blank (see
+    //   RnntGreedyDecoder's punct-bias comment) -- appropriate at a genuine
+    //   end of stream, wrong here: an ordinary mid-utterance pause is not
+    //   grammatically "the end of a sentence," and forcing punctuation there
+    //   is exactly the class of bug this fix removes.
+    //
+    // fire_eou's own Decoder::reset_utterance() (not reset()) already is the
+    // right-sized reset for a checkpoint like this: see reset_utterance()'s
+    // doc comment -- "soft utterance reset for callers that intentionally
+    // preserve predictor context."
     fire_eou(head_.get(), opts_, all_tokens_, transcript_, update);
-
-    // An EOU is a decoder boundary, not a new audio stream. Reset model state
-    // and segment-local buffers while retaining global FE/VAD cursors and the
-    // absolute encoder-frame clock.
-    if (head_)
-        head_->reset();
-    zero_caches();
-    cache_filled_frames_ = 0;
-    std::fill(attn_mask_.begin(), attn_mask_.end(), 0.0f);
-    mel_buf_ = std::move(next_mel);
-    mel_offset_ = 0;
-    stream_zero_padded_ = false;
-    total_frames_emitted_ = real_frames_emitted;
-    chunks_processed_ = real_chunks_processed;
-    last_enc_out_.clear();
-    last_enc_T_ = 0;
-    finalizing_ = false;
 }
 
 bool
-CacheStreamRunner::poll_endpoint(StreamingUpdate& update, bool after_chunk) {
+CacheStreamRunner::poll_endpoint(StreamingUpdate& update) {
     if (!endpointer_ || finalizing_)
         return false;
     const int sample_rate = model_->fe_config().sample_rate;
@@ -1131,9 +1105,7 @@ CacheStreamRunner::poll_endpoint(StreamingUpdate& update, bool after_chunk) {
     }
     if (!endpointer_->poll(now_ms, last_speech_ms))
         return false;
-    const bool preserve_buffered_future = after_chunk && !force_eou_pending_;
-    force_eou_pending_ = false;
-    finish_endpoint(update, preserve_buffered_future);
+    finish_endpoint(update);
     return true;
 }
 
@@ -1264,7 +1236,6 @@ CacheStreamRunner::reset() {
     audio_fed_to_vad_ = 0;
     if (endpointer_)
         endpointer_->reset();
-    force_eou_pending_ = false;
     vad_scan_frame_ = 0;
     vad_speech_seen_frame_ = -1;
     cache_filled_frames_ = 0;

--- a/src/asr/runner.h
+++ b/src/asr/runner.h
@@ -277,15 +277,24 @@ class CacheStreamRunner final : public AsrRunner {
 
    private:
     void process_one_chunk(bool /*is_last*/);
-    void finish_endpoint(StreamingUpdate& update, bool preserve_buffered_future);
+    // A mid-stream EOU is a reporting checkpoint, not an audio-stream
+    // boundary: it snapshots is_final=true/transcript_so_far for the caller
+    // but leaves encoder cache and predictor state alone, so the *next*
+    // segment naturally continues the same utterance (right capitalization,
+    // no spurious terminal punctuation, no lost acoustic/linguistic
+    // context). See fire_eou's already-soft Decoder::reset_utterance() (not
+    // Decoder::reset()) -- this just stops layering a second, harder reset
+    // on top of it.
+    void finish_endpoint(StreamingUpdate& update);
     void upload_attn_mask();
     void zero_caches();
     // Poll the endpointer on the decode clock (now = encoder frames emitted;
     // last speech = VAD bits over decoded mel frames, or the decoder's
-    // last_emit_frame). Called after each processed chunk. On EOU it runs the
-    // normal EOS path, then starts the next utterance with fresh encoder and
-    // predictor state. The chunk loop breaks when this returns true.
-    bool poll_endpoint(StreamingUpdate& update, bool after_chunk);
+    // last_emit_frame). Called after each processed chunk. On EOU it reports
+    // a soft checkpoint via finish_endpoint (see its doc comment) -- encoder
+    // and predictor state carry on unchanged. The chunk loop breaks when
+    // this returns true.
+    bool poll_endpoint(StreamingUpdate& update);
     // Drop the audio prefix that FE and VAD have both consumed.
     void trim_buffers();
     void compact_mel_buffer();
@@ -321,12 +330,12 @@ class CacheStreamRunner final : public AsrRunner {
     // GLOBAL sample count already fed to vad_.
     size_t audio_fed_to_vad_ = 0;
 
-    // Always constructed so force_eou() works with threshold endpointing off. Polled
-    // after each chunk; on fire the runner emits is_final and resets
-    // per-utterance state. Encoder and predictor state are reset at the
-    // boundary so delayed tokens cannot leak into the next utterance.
+    // Always constructed so force_eou() works with threshold endpointing off.
+    // Polled after each chunk; on fire the runner emits is_final as a soft
+    // reporting checkpoint (see finish_endpoint's doc comment) -- encoder and
+    // predictor state are deliberately NOT reset at the boundary, so the next
+    // segment keeps full acoustic/linguistic context.
     std::unique_ptr<VadEndpointer> endpointer_;
-    bool force_eou_pending_ = false;
     // VAD-driven EOU scan state: next global mel frame to scan, and the last
     // speech mel frame seen at or before the decode cursor.
     int64_t vad_scan_frame_ = 0;

--- a/src/asr/runner.h
+++ b/src/asr/runner.h
@@ -277,23 +277,14 @@ class CacheStreamRunner final : public AsrRunner {
 
    private:
     void process_one_chunk(bool /*is_last*/);
-    // A mid-stream EOU is a reporting checkpoint, not an audio-stream
-    // boundary: it snapshots is_final=true/transcript_so_far for the caller
-    // but leaves encoder cache and predictor state alone, so the *next*
-    // segment naturally continues the same utterance (right capitalization,
-    // no spurious terminal punctuation, no lost acoustic/linguistic
-    // context). See fire_eou's already-soft Decoder::reset_utterance() (not
-    // Decoder::reset()) -- this just stops layering a second, harder reset
-    // on top of it.
+    // Mid-stream EOU: a reporting checkpoint, not a decoder reset -- encoder
+    // cache and predictor state carry on so the next segment stays in
+    // context (see fire_eou's Decoder::reset_utterance()).
     void finish_endpoint(StreamingUpdate& update);
     void upload_attn_mask();
     void zero_caches();
-    // Poll the endpointer on the decode clock (now = encoder frames emitted;
-    // last speech = VAD bits over decoded mel frames, or the decoder's
-    // last_emit_frame). Called after each processed chunk. On EOU it reports
-    // a soft checkpoint via finish_endpoint (see its doc comment) -- encoder
-    // and predictor state carry on unchanged. The chunk loop breaks when
-    // this returns true.
+    // Poll the endpointer on the decode clock. On EOU, reports via
+    // finish_endpoint. Chunk loop breaks when this returns true.
     bool poll_endpoint(StreamingUpdate& update);
     // Drop the audio prefix that FE and VAD have both consumed.
     void trim_buffers();
@@ -331,10 +322,6 @@ class CacheStreamRunner final : public AsrRunner {
     size_t audio_fed_to_vad_ = 0;
 
     // Always constructed so force_eou() works with threshold endpointing off.
-    // Polled after each chunk; on fire the runner emits is_final as a soft
-    // reporting checkpoint (see finish_endpoint's doc comment) -- encoder and
-    // predictor state are deliberately NOT reset at the boundary, so the next
-    // segment keeps full acoustic/linguistic context.
     std::unique_ptr<VadEndpointer> endpointer_;
     // VAD-driven EOU scan state: next global mel frame to scan, and the last
     // speech mel frame seen at or before the decode cursor.

--- a/tests/cpp/asr/test_endpointer.cpp
+++ b/tests/cpp/asr/test_endpointer.cpp
@@ -51,12 +51,7 @@ starts_with_attach_punctuation(const std::string& text) {
            tail.rfind("\xEF\xBC\x9F", 0) == 0;
 }
 
-// A continuation is only legitimately capitalized if whatever came right
-// before it actually ended a sentence. Audio-content-agnostic on purpose (no
-// assumption about what words are in the clip) -- this is exactly the
-// correctness property a hard per-utterance reset at a false-positive
-// mid-sentence EOU breaks: the next segment gets capitalized as if it were a
-// brand new, unrelated utterance.
+// Detects a continuation capitalized as if it started a new sentence.
 static bool
 starts_with_uppercase_letter(const std::string& text) {
     const size_t first = text.find_first_not_of(" \t\r\n");
@@ -179,11 +174,9 @@ test_integration(int argc, char** argv) {
     cfg.vad.model_path = vad_model;
     cfg.vad.masker.mask_enable = !no_masking;
     cfg.endpointing = ep;
-    // -1 = the model's own trained cache-aware right-context (see
-    // StreamingConfig::rnnt_right_context's doc comment) -- NOT hardcoded to
-    // 1, which isn't even a supported context size for every RNNT model
-    // (e.g. nemotron-3.5-asr-streaming trains at R=3, and only exposes
-    // {0,3,6,13}); the CTC runner ignores this either way.
+    // -1 = model's trained right-context; 1 isn't a supported value for
+    // every RNNT model (e.g. nemotron-3.5-asr-streaming only supports
+    // {0,3,6,13}).
     cfg.streaming.rnnt_right_context = -1;
 
     std::unique_ptr<AsrRunner> runner;
@@ -192,11 +185,8 @@ test_integration(int argc, char** argv) {
     } else {
         runner = std::make_unique<BufferedStreamRunner>(static_cast<CtcModel*>(model.get()), cfg);
     }
-    // Prompt-conditioned multilingual RNNT models (nemotron-3.5) need a
-    // prompt slot set before they'll decode at all -- Recognizer::
-    // streaming_recognize always does this (see recognizer.cpp); this
-    // harness constructs runners directly, bypassing Recognizer, so it has
-    // to do the same. No-op (returns -1) for non-prompt models.
+    // Required for prompt-conditioned models (nemotron-3.5); Recognizer
+    // normally does this, but this harness bypasses Recognizer.
     runner->set_prompt_index(model->prompt_index_for_lang("auto"));
     AsrRequestOptions request_options;
     request_options.enable_word_time_offsets = true;
@@ -281,22 +271,12 @@ test_integration(int argc, char** argv) {
     check(
         leading_punctuation == 0,
         "integration: terminal punctuation does not leak into the next final");
-    // Catches what leading_punctuation above doesn't: a continuation
-    // capitalized as if it started a fresh, unrelated utterance. Can't use
-    // the previous segment's own trailing punctuation to decide whether
-    // capitalization is justified here -- a leaked/spurious terminal '.'/'?'
-    // is itself a symptom of the exact same bug (the finalizing_ EOU
-    // punctuation floor firing on a false mid-sentence EOU), so trusting it
-    // would validate the bug using its own artifact. Instead, use ground
-    // truth this harness itself controls: `audio` is built as
-    // [one utterance | gap silence | one utterance], so no real utterance-2
-    // content has even been fed to the runner until audio_processed_sec
-    // reaches the end of the gap -- any final reported before then, however
-    // delayed by decode lag, can only be describing utterance 1, by
-    // construction never a real utterance boundary, and must never be
-    // capitalized (this is the primary symptom of a false-positive
-    // mid-sentence EOU hard-resetting decoder state; see
-    // CacheStreamRunner::finish_endpoint's doc comment).
+    // Catches what leading_punctuation doesn't: spurious capitalization.
+    // Can't trust the previous segment's own trailing punctuation as
+    // justification -- a leaked '.'/'?' is itself a symptom of the same bug.
+    // Instead use ground truth this harness controls: no utterance-2 audio
+    // is fed until the gap ends, so any final before that point can only be
+    // an internal (never legitimate) split of utterance 1.
     const float first_utterance_and_gap_sec =
         static_cast<float>(one.size()) / static_cast<float>(sr) +
         static_cast<float>(gap_ms) / 1000.0f;

--- a/tests/cpp/asr/test_endpointer.cpp
+++ b/tests/cpp/asr/test_endpointer.cpp
@@ -14,6 +14,7 @@
 // Usage: ./test_endpointer [<model.gguf> <audio.wav> [--gpu N] [--vad-model F]
 //                           [--chunk-ms N] [--gap-ms N] [--eou-ms N]]
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
@@ -48,6 +49,20 @@ starts_with_attach_punctuation(const std::string& text) {
     return tail.rfind("\xE0\xA5\xA4", 0) == 0 || tail.rfind("\xE0\xA5\xA5", 0) == 0 ||
            tail.rfind("\xE3\x80\x82", 0) == 0 || tail.rfind("\xEF\xBC\x81", 0) == 0 ||
            tail.rfind("\xEF\xBC\x9F", 0) == 0;
+}
+
+// A continuation is only legitimately capitalized if whatever came right
+// before it actually ended a sentence. Audio-content-agnostic on purpose (no
+// assumption about what words are in the clip) -- this is exactly the
+// correctness property a hard per-utterance reset at a false-positive
+// mid-sentence EOU breaks: the next segment gets capitalized as if it were a
+// brand new, unrelated utterance.
+static bool
+starts_with_uppercase_letter(const std::string& text) {
+    const size_t first = text.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos)
+        return false;
+    return std::isupper(static_cast<unsigned char>(text[first])) != 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +179,12 @@ test_integration(int argc, char** argv) {
     cfg.vad.model_path = vad_model;
     cfg.vad.masker.mask_enable = !no_masking;
     cfg.endpointing = ep;
-    cfg.streaming.rnnt_right_context = 1;  // R=1 for RNNT; the CTC runner ignores it
+    // -1 = the model's own trained cache-aware right-context (see
+    // StreamingConfig::rnnt_right_context's doc comment) -- NOT hardcoded to
+    // 1, which isn't even a supported context size for every RNNT model
+    // (e.g. nemotron-3.5-asr-streaming trains at R=3, and only exposes
+    // {0,3,6,13}); the CTC runner ignores this either way.
+    cfg.streaming.rnnt_right_context = -1;
 
     std::unique_ptr<AsrRunner> runner;
     if (model->head_kind() == HeadKind::Rnnt) {
@@ -172,6 +192,12 @@ test_integration(int argc, char** argv) {
     } else {
         runner = std::make_unique<BufferedStreamRunner>(static_cast<CtcModel*>(model.get()), cfg);
     }
+    // Prompt-conditioned multilingual RNNT models (nemotron-3.5) need a
+    // prompt slot set before they'll decode at all -- Recognizer::
+    // streaming_recognize always does this (see recognizer.cpp); this
+    // harness constructs runners directly, bypassing Recognizer, so it has
+    // to do the same. No-op (returns -1) for non-prompt models.
+    runner->set_prompt_index(model->prompt_index_for_lang("auto"));
     AsrRequestOptions request_options;
     request_options.enable_word_time_offsets = true;
     runner->set_request_options(request_options);
@@ -187,7 +213,7 @@ test_integration(int argc, char** argv) {
         ep_off.enable = false;
         RecognizerConfig pcfg;
         pcfg.endpointing = ep_off;
-        pcfg.streaming.rnnt_right_context = 1;  // R=1 for RNNT; the CTC runner ignores it
+        pcfg.streaming.rnnt_right_context = -1;  // model default -- see cfg above
         std::unique_ptr<AsrRunner> probe;
         if (model->head_kind() == HeadKind::Rnnt) {
             probe = std::make_unique<CacheStreamRunner>(static_cast<RnntModel*>(model.get()), pcfg);
@@ -195,6 +221,7 @@ test_integration(int argc, char** argv) {
             probe =
                 std::make_unique<BufferedStreamRunner>(static_cast<CtcModel*>(model.get()), pcfg);
         }
+        probe->set_prompt_index(model->prompt_index_for_lang("auto"));
         const size_t head = std::min(audio.size(), static_cast<size_t>(4) * sr);
         for (size_t off = 0; off < head; off += chunk_samples) {
             const size_t n = std::min(chunk_samples, head - off);
@@ -211,9 +238,11 @@ test_integration(int argc, char** argv) {
     }
 
     std::vector<std::string> finals;
+    std::vector<float> final_audio_processed_sec;
     std::vector<int64_t> first_word_frames;
     const auto record_final = [&](const StreamingUpdate& update) {
         finals.push_back(update.transcript_so_far);
+        final_audio_processed_sec.push_back(update.audio_processed_sec);
         if (!update.words.empty())
             first_word_frames.push_back(update.words.front().start_frame);
     };
@@ -252,6 +281,37 @@ test_integration(int argc, char** argv) {
     check(
         leading_punctuation == 0,
         "integration: terminal punctuation does not leak into the next final");
+    // Catches what leading_punctuation above doesn't: a continuation
+    // capitalized as if it started a fresh, unrelated utterance. Can't use
+    // the previous segment's own trailing punctuation to decide whether
+    // capitalization is justified here -- a leaked/spurious terminal '.'/'?'
+    // is itself a symptom of the exact same bug (the finalizing_ EOU
+    // punctuation floor firing on a false mid-sentence EOU), so trusting it
+    // would validate the bug using its own artifact. Instead, use ground
+    // truth this harness itself controls: `audio` is built as
+    // [one utterance | gap silence | one utterance], so no real utterance-2
+    // content has even been fed to the runner until audio_processed_sec
+    // reaches the end of the gap -- any final reported before then, however
+    // delayed by decode lag, can only be describing utterance 1, by
+    // construction never a real utterance boundary, and must never be
+    // capitalized (this is the primary symptom of a false-positive
+    // mid-sentence EOU hard-resetting decoder state; see
+    // CacheStreamRunner::finish_endpoint's doc comment).
+    const float first_utterance_and_gap_sec =
+        static_cast<float>(one.size()) / static_cast<float>(sr) +
+        static_cast<float>(gap_ms) / 1000.0f;
+    int spurious_capitalization = 0;
+    for (size_t i = 1; i < finals.size(); i++) {
+        if (finals[i].empty())
+            continue;
+        if (final_audio_processed_sec[i] >= first_utterance_and_gap_sec)
+            continue;  // at/after this point a real utterance boundary is possible
+        if (starts_with_uppercase_letter(finals[i]))
+            spurious_capitalization++;
+    }
+    check(
+        spurious_capitalization == 0,
+        "integration: no internal split of the first utterance is capitalized as a new sentence");
     check(
         first_word_frames.size() >= 2 &&
             std::is_sorted(first_word_frames.begin(), first_word_frames.end()),


### PR DESCRIPTION
Fixes #40.

## Problem
- A mid-stream EOU (token-silence method) fires on ordinary conversational pauses, not just real end-of-utterance.
- `CacheStreamRunner::finish_endpoint` treated every EOU as a hard boundary: reset encoder cache + predictor state, and flushed a synthetic zero-padded tail that biases the RNNT head to emit a terminal `.`/`?`.
- Result on an ordinary mid-sentence pause: next segment decodes as a brand new utterance (wrong capitalization) plus a spurious terminal punctuation mark.

### Example (real recording, `--stream --endpointing --stop-history-eou-ms 700`)

| | Output |
|---|---|
| Before | "...have a look at how**?** **W**e package our profiles and what the **D**efault profile settings are that we should" |
| After | "...have a look at how we package up profiles and what the default profile settings are that we should" |
| Batch decode (reference) | "...have a look at how we package a profiles and what the default profile settings are that we ship it." |

Same real recording, via `test_endpointer`'s integration test (each row a separate `is_final`):

| Before (3 finals) | After (4 finals) |
|---|---|
| "In a new work tree based on Maine, can you please have a look at how?" | "In a new work tree based on Maine, can you please have a look at" |
| **"W**e package our profiles and what the default profile settings are that we should." | "how we package up profiles" |
| | "and what the default profile settings are that we should" |

## Fix
- `fire_eou` already does the right-sized reset for this: `Decoder::reset_utterance()` ("soft utterance reset ... preserves predictor context"). It was being called, then immediately overridden by a second, harder reset in `finish_endpoint`.
- Removed that second reset and the now-unneeded synthetic tail-flush / `mel_buf_` preserve-split logic that existed to support it. The next segment now just continues the same utterance with full context, like any ordinary chunk boundary.
- Dropped `force_eou_pending_` and `poll_endpoint`/`finish_endpoint`'s `after_chunk`/`preserve_buffered_future` params, both dead once the `mel_buf_` split logic is gone.

## Also fixed: `test_endpointer`'s RNNT integration test
- It was silently broken against a prompt-conditioned multilingual model (nemotron-3.5): constructs `CacheStreamRunner` directly, bypassing `Recognizer`, and never called `set_prompt_index()`. Also hardcoded an unsupported `rnnt_right_context = 1`. Both now match `Recognizer`.
- Its only capitalization-adjacent check only caught a leaked punctuation mark, not spurious capitalization (the actual bug). Added a real check, using the test's own known audio structure as ground truth rather than trusting the model's own (possibly-buggy) trailing punctuation.

## Testing
- `test_endpointer` policy suite (13 cases, no model): passes unchanged.
- `test_endpointer` integration test against nemotron-3.5-asr-streaming-0.6b: new/fixed checks fail on pre-fix runner code, pass on the fix.
- Manual CLI repro (`--stream --endpointing --stop-history-eou-ms 700`) on two real recordings: streaming+endpointing now matches batch and streaming-without-endpointing output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved endpoint handling during streaming transcription by preserving encoder and prediction state when an utterance-end event is reported.
  - Automatic and manually triggered endpoint events now follow consistent handling, improving continuity across subsequent audio.
  - Reduced incorrect capitalization when an utterance is internally split at an endpoint.
- **Improvements**
  - Streaming endpoint behavior now supports model-configured right context more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->