### PR TITLE
fix(tts): end a chunk when attention reaches the last tokens of its text

### DIFF
--- a/src/tts/magpietts/model.cpp
+++ b/src/tts/magpietts/model.cpp
@@ -1780,11 +1780,16 @@ MagpieLongformAttentionPriorState::update(
     }
     const int last_rel = std::max(0, std::min(search_start_abs - left_offset_, text_len_ - 1));
 
-    int attended_rel = last_rel;
     const int search_end =
         std::min(last_rel + std::max(0, h.attention_prior_lookahead_window), text_len_ - 3);
+    // An empty search window means attention has reached the last few tokens of
+    // the text: the reference treats that as the sentence having ended and jumps
+    // to the final position, which is what lets the chunk finish. Holding at
+    // last_rel instead leaves the chunk creeping forward one token per
+    // advance_threshold steps, on the sink escape alone -- which is where
+    // degenerate chunks running 291 steps against a mean of 120 came from.
+    int attended_rel = search_end > last_rel ? last_rel : text_len_ - 1;
     if (search_end > last_rel) {
-        attended_rel = last_rel;
         float best = alignment_scores[(size_t)last_rel];
         for (int i = last_rel + 1; i < search_end; ++i) {
             if (alignment_scores[(size_t)i] > best) {


### PR DESCRIPTION
The long-form attention prior searches a lookahead window that starts at the last attended text position and is clamped to `text_len - 3`. Once attention gets within three tokens of the end, that window is empty. The reference treats an empty window as the sentence having ended and jumps to the final position:

```python
# nemo/collections/tts/models/magpietts.py
if item_attention_scores.size(0) == 0:
    # This means the sentence has ended
    attended_timestep = text_lens[bidx].item() - 1 + left_offset[bidx]
```

We held at the last attended position instead. The chunk then advanced only through the attention-sink escape -- one text token per `attention_prior_advance_threshold` steps, which ships as 8 -- so every chunk paid a crawl at its end, and a chunk whose attention was already sluggish paid a long one.

Everything else in the port matches. The counter is indexed absolutely on both sides, the escape check reads the same index, the window is half-open in both, and the argmax-to-absolute arithmetic is equivalent: NeMo's `argmax + last` and our `left_offset + i` differ only in how the same value is assembled.

## Effect

Measured on GB300, greedy, `--tts.batch-size 32 --tts.chunk-frames 32`:

| input | RTF | mean steps per chunk |
|---|---|---|
| twenty-sentence script | 0.0083 -> **0.0078** | 114 -> **98** |
| 16 sentences of prose | 0.0115 -> **0.0110** | 119 -> **103** |
| 32 sentences of prose | 0.0094 -> **0.0090** | 129 -> **113** |

About 14% fewer decode steps. The prose cases are sampled from public-domain text, whose short sentences reach the clamp more often than a repeated benchmark line does.

## Validation

- Every chunk still ends through attention reaching its text end: 20/20 and 38/38, zero budget exhaustions, no chunk stopping short of its text.
- Audio shortens slightly as the trailing crawl disappears -- 99.85 s to 99.1 s on the script -- and a listening check on that pair passed.
- Output stays reproducible: three runs each hash identically.

**This re-baselines the reproducibility hashes**, since it changes output on every path including sequential:

```
line       556d091e3e71a90e
paragraph  022ba2aafb00cd74
script     67bfc60505c7890a
```

## What it does not fix

Max/mean per-chunk steps stays near 1.9 on prose, so chunks still vary widely in length and a lockstep batch still pays for its slowest member. This removes the floor every chunk paid, not the tail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved long-form text alignment by advancing to the final text position when no valid search window is available.
  * Preserved existing lookahead-based alignment behavior when a search window is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->